### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 Generate You Projects
 ===================================
 
-Documentation is available at [http://gyp3.org/](http://gyp3.org/) (or at the `md-pages` branch).
+Documentation is available at [http://gyp3.org/](http://gyp3.org/) (or at the [`gh-pages`](https://github.com/refack/GYP/blob/gh-pages/index.md) branch).

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 Generate You Projects
 ===================================
 
-Documentation is available at [https://refack.github.io/GYP/](https://refack.github.io/GYP/) (or at the `md-pages` branch).
+Documentation is available at [http://gyp3.org/](http://gyp3.org/) (or at the `md-pages` branch).

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 Generate You Projects
 ===================================
 
-Documentation is available at [gyp.gsrc.io](https://gyp.gsrc.io) (or at the `md-pages` branch).
+Documentation is available at [https://refack.github.io/GYP/](https://refack.github.io/GYP/) (or at the `md-pages` branch).

--- a/buildbot/buildbot_run.py
+++ b/buildbot/buildbot_run.py
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 
 """Argument-less script to select what to run on the buildbots."""
+from __future__ import print_function
 
 import os
 import shutil
@@ -24,14 +25,14 @@ def CallSubProcess(*args, **kwargs):
   with open(os.devnull) as devnull_fd:
     retcode = subprocess.call(stdin=devnull_fd, *args, **kwargs)
   if retcode != 0:
-    print '@@@STEP_EXCEPTION@@@'
+    print('@@@STEP_EXCEPTION@@@')
     sys.exit(1)
 
 
 def PrepareCmake():
   """Build CMake 2.8.8 since the version in Precise is 2.8.7."""
   if os.environ['BUILDBOT_CLOBBER'] == '1':
-    print '@@@BUILD_STEP Clobber CMake checkout@@@'
+    print('@@@BUILD_STEP Clobber CMake checkout@@@')
     shutil.rmtree(CMAKE_DIR)
 
   # We always build CMake 2.8.8, so no need to do anything
@@ -39,10 +40,10 @@ def PrepareCmake():
   if os.path.isdir(CMAKE_DIR):
     return
 
-  print '@@@BUILD_STEP Initialize CMake checkout@@@'
+  print('@@@BUILD_STEP Initialize CMake checkout@@@')
   os.mkdir(CMAKE_DIR)
 
-  print '@@@BUILD_STEP Sync CMake@@@'
+  print('@@@BUILD_STEP Sync CMake@@@')
   CallSubProcess(
       ['git', 'clone',
        '--depth', '1',
@@ -53,7 +54,7 @@ def PrepareCmake():
        CMAKE_DIR],
       cwd=CMAKE_DIR)
 
-  print '@@@BUILD_STEP Build CMake@@@'
+  print('@@@BUILD_STEP Build CMake@@@')
   CallSubProcess(
       ['/bin/bash', 'bootstrap', '--prefix=%s' % CMAKE_DIR],
       cwd=CMAKE_DIR)
@@ -74,7 +75,7 @@ def GypTestFormat(title, format=None, msvs_version=None, tests=[]):
   if not format:
     format = title
 
-  print '@@@BUILD_STEP ' + title + '@@@'
+  print('@@@BUILD_STEP ' + title + '@@@')
   sys.stdout.flush()
   env = os.environ.copy()
   if msvs_version:
@@ -89,17 +90,17 @@ def GypTestFormat(title, format=None, msvs_version=None, tests=[]):
   retcode = subprocess.call(command, cwd=ROOT_DIR, env=env, shell=True)
   if retcode:
     # Emit failure tag, and keep going.
-    print '@@@STEP_FAILURE@@@'
+    print('@@@STEP_FAILURE@@@')
     return 1
   return 0
 
 
 def GypBuild():
   # Dump out/ directory.
-  print '@@@BUILD_STEP cleanup@@@'
-  print 'Removing %s...' % OUT_DIR
+  print('@@@BUILD_STEP cleanup@@@')
+  print('Removing %s...' % OUT_DIR)
   shutil.rmtree(OUT_DIR, ignore_errors=True)
-  print 'Done.'
+  print('Done.')
 
   retcode = 0
   if sys.platform.startswith('linux'):
@@ -128,7 +129,7 @@ def GypBuild():
     #     after the build proper that could be used for cumulative failures),
     #     use that instead of this. This isolates the final return value so
     #     that it isn't misattributed to the last stage.
-    print '@@@BUILD_STEP failures@@@'
+    print('@@@BUILD_STEP failures@@@')
     sys.exit(retcode)
 
 

--- a/pylib/gyp/MSVSSettings.py
+++ b/pylib/gyp/MSVSSettings.py
@@ -461,7 +461,7 @@ def ConvertToMSBuildSettings(msvs_settings, stderr=sys.stderr):
           # Invoke the translation function.
           try:
             msvs_tool[msvs_setting](msvs_value, msbuild_settings)
-          except ValueError, e:
+          except ValueError as e:
             print >> stderr, ('Warning: while converting %s/%s to MSBuild, '
                               '%s' % (msvs_tool_name, msvs_setting, e))
         else:
@@ -517,7 +517,7 @@ def _ValidateSettings(validators, settings, stderr):
         if setting in tool_validators:
           try:
             tool_validators[setting](value)
-          except ValueError, e:
+          except ValueError as e:
             print >> stderr, ('Warning: for %s/%s, %s' %
                               (tool_name, setting, e))
         else:

--- a/pylib/gyp/MSVSVersion.py
+++ b/pylib/gyp/MSVSVersion.py
@@ -189,7 +189,7 @@ def _RegistryQuery(key, value=None):
   text = None
   try:
     text = _RegistryQueryBase('Sysnative', key, value)
-  except OSError, e:
+  except OSError as e:
     if e.errno == errno.ENOENT:
       text = _RegistryQueryBase('System32', key, value)
     else:

--- a/pylib/gyp/__init__.py
+++ b/pylib/gyp/__init__.py
@@ -4,6 +4,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+from __future__ import print_function
 import copy
 import gyp.input
 import optparse
@@ -34,8 +35,8 @@ def DebugOutput(mode, message, *args):
       pass
     if args:
       message %= args
-    print '%s:%s:%d:%s %s' % (mode.upper(), os.path.basename(ctx[0]),
-                              ctx[1], ctx[2], message)
+    print('%s:%s:%d:%s %s' % (mode.upper(), os.path.basename(ctx[0]),
+                              ctx[1], ctx[2], message))
 
 def FindBuildFiles():
   extension = '.gyp'
@@ -226,12 +227,12 @@ def RegenerateFlags(options):
           (action == 'store_false' and not value)):
         flags.append(opt)
       elif options.use_environment and env_name:
-        print >>sys.stderr, ('Warning: environment regeneration unimplemented '
+        print(('Warning: environment regeneration unimplemented '
                              'for %s flag %r env_name %r' % (action, opt,
-                                                             env_name))
+                                                             env_name)), file=sys.stderr)
     else:
-      print >>sys.stderr, ('Warning: regeneration unimplemented for action %r '
-                           'flag %r' % (action, opt))
+      print(('Warning: regeneration unimplemented for action %r '
+                           'flag %r' % (action, opt)), file=sys.stderr)
 
   return flags
 
@@ -475,7 +476,7 @@ def gyp_main(args):
   if home_dot_gyp != None:
     default_include = os.path.join(home_dot_gyp, 'include.gypi')
     if os.path.exists(default_include):
-      print 'Using overrides found in ' + default_include
+      print('Using overrides found in ' + default_include)
       includes.append(default_include)
 
   # Command-line --include files come after the default include.
@@ -536,7 +537,7 @@ def gyp_main(args):
 def main(args):
   try:
     return gyp_main(args)
-  except GypError, e:
+  except GypError as e:
     sys.stderr.write("gyp: %s\n" % e)
     return 1
 

--- a/pylib/gyp/common.py
+++ b/pylib/gyp/common.py
@@ -363,7 +363,7 @@ def WriteOnDiff(filename):
         same = False
         try:
           same = filecmp.cmp(self.tmp_path, filename, False)
-        except OSError, e:
+        except OSError as e:
           if e.errno != errno.ENOENT:
             raise
 
@@ -382,9 +382,9 @@ def WriteOnDiff(filename):
           #
           # No way to get the umask without setting a new one?  Set a safe one
           # and then set it back to the old value.
-          umask = os.umask(077)
+          umask = os.umask(0o77)
           os.umask(umask)
-          os.chmod(self.tmp_path, 0666 & ~umask)
+          os.chmod(self.tmp_path, 0o666 & ~umask)
           if sys.platform == 'win32' and os.path.exists(filename):
             # NOTE: on windows (but not cygwin) rename will not replace an
             # existing file, so it must be preceded with a remove. Sadly there
@@ -471,7 +471,7 @@ def CopyTool(flavor, out_path, generator_flags={}):
         ''.join([source[0], header] + source[1:]))
 
   # Make file executable.
-  os.chmod(tool_path, 0755)
+  os.chmod(tool_path, 0o755)
 
 
 # From Alex Martelli,

--- a/pylib/gyp/easy_xml.py
+++ b/pylib/gyp/easy_xml.py
@@ -5,6 +5,7 @@
 import re
 import os
 import locale
+from functools import reduce
 
 
 def XmlToString(content, encoding='utf-8', pretty=False):

--- a/pylib/gyp/flock_tool.py
+++ b/pylib/gyp/flock_tool.py
@@ -39,7 +39,7 @@ class FlockTool(object):
     # where fcntl.flock(fd, LOCK_EX) always fails
     # with EBADF, that's why we use this F_SETLK
     # hack instead.
-    fd = os.open(lockfile, os.O_WRONLY|os.O_NOCTTY|os.O_CREAT, 0666)
+    fd = os.open(lockfile, os.O_WRONLY|os.O_NOCTTY|os.O_CREAT, 0o666)
     if sys.platform.startswith('aix'):
       # Python on AIX is compiled with LARGEFILE support, which changes the
       # struct size.

--- a/pylib/gyp/generator/analyzer.py
+++ b/pylib/gyp/generator/analyzer.py
@@ -61,6 +61,7 @@ Notice that "b1" and "b2" are not in the "all" target as "b.gyp" was not
 directly supplied to gyp. OTOH if both "a.gyp" and "b.gyp" are supplied to gyp
 then the "all" target includes "b1" and "b2".
 """
+from __future__ import print_function
 
 import gyp.common
 import gyp.ninja_syntax as ninja_syntax
@@ -155,7 +156,7 @@ def _AddSources(sources, base_path, base_path_components, result):
       continue
     result.append(base_path + source)
     if debug:
-      print 'AddSource', org_source, result[len(result) - 1]
+      print('AddSource', org_source, result[len(result) - 1])
 
 
 def _ExtractSourcesFromAction(action, base_path, base_path_components,
@@ -185,7 +186,7 @@ def _ExtractSources(target, target_dict, toplevel_dir):
     base_path += '/'
 
   if debug:
-    print 'ExtractSources', target, base_path
+    print('ExtractSources', target, base_path)
 
   results = []
   if 'sources' in target_dict:
@@ -278,7 +279,7 @@ def _WasBuildFileModified(build_file, data, files, toplevel_dir):
   the root of the source tree."""
   if _ToLocalPath(toplevel_dir, _ToGypPath(build_file)) in files:
     if debug:
-      print 'gyp file modified', build_file
+      print('gyp file modified', build_file)
     return True
 
   # First element of included_files is the file itself.
@@ -291,8 +292,8 @@ def _WasBuildFileModified(build_file, data, files, toplevel_dir):
         _ToGypPath(gyp.common.UnrelativePath(include_file, build_file))
     if _ToLocalPath(toplevel_dir, rel_include_file) in files:
       if debug:
-        print 'included gyp file modified, gyp_file=', build_file, \
-            'included file=', rel_include_file
+        print('included gyp file modified, gyp_file=', build_file, \
+            'included file=', rel_include_file)
       return True
   return False
 
@@ -373,7 +374,7 @@ def _GenerateTargets(data, target_list, target_dicts, toplevel_dir, files,
     # If a build file (or any of its included files) is modified we assume all
     # targets in the file are modified.
     if build_file_in_files[build_file]:
-      print 'matching target from modified build file', target_name
+      print('matching target from modified build file', target_name)
       target.match_status = MATCH_STATUS_MATCHES
       matching_targets.append(target)
     else:
@@ -381,7 +382,7 @@ def _GenerateTargets(data, target_list, target_dicts, toplevel_dir, files,
                                 toplevel_dir)
       for source in sources:
         if _ToGypPath(os.path.normpath(source)) in files:
-          print 'target', target_name, 'matches', source
+          print('target', target_name, 'matches', source)
           target.match_status = MATCH_STATUS_MATCHES
           matching_targets.append(target)
           break
@@ -433,7 +434,7 @@ def _DoesTargetDependOnMatchingTargets(target):
   for dep in target.deps:
     if _DoesTargetDependOnMatchingTargets(dep):
       target.match_status = MATCH_STATUS_MATCHES_BY_DEPENDENCY
-      print '\t', target.name, 'matches by dep', dep.name
+      print('\t', target.name, 'matches by dep', dep.name)
       return True
   target.match_status = MATCH_STATUS_DOESNT_MATCH
   return False
@@ -445,7 +446,7 @@ def _GetTargetsDependingOnMatchingTargets(possible_targets):
   supplied as input to analyzer.
   possible_targets: targets to search from."""
   found = []
-  print 'Targets that matched by dependency:'
+  print('Targets that matched by dependency:')
   for target in possible_targets:
     if _DoesTargetDependOnMatchingTargets(target):
       found.append(target)
@@ -484,12 +485,12 @@ def _AddCompileTargets(target, roots, add_if_no_ancestor, result):
           (add_if_no_ancestor or target.requires_build)) or
          (target.is_static_library and add_if_no_ancestor and
           not target.is_or_has_linked_ancestor)):
-    print '\t\tadding to compile targets', target.name, 'executable', \
+    print('\t\tadding to compile targets', target.name, 'executable', \
            target.is_executable, 'added_to_compile_targets', \
            target.added_to_compile_targets, 'add_if_no_ancestor', \
            add_if_no_ancestor, 'requires_build', target.requires_build, \
            'is_static_library', target.is_static_library, \
-           'is_or_has_linked_ancestor', target.is_or_has_linked_ancestor
+           'is_or_has_linked_ancestor', target.is_or_has_linked_ancestor)
     result.add(target)
     target.added_to_compile_targets = True
 
@@ -500,7 +501,7 @@ def _GetCompileTargets(matching_targets, supplied_targets):
   supplied_targets: set of targets supplied to analyzer to search from."""
   result = set()
   for target in matching_targets:
-    print 'finding compile targets for match', target.name
+    print('finding compile targets for match', target.name)
     _AddCompileTargets(target, supplied_targets, True, result)
   return result
 
@@ -508,46 +509,46 @@ def _GetCompileTargets(matching_targets, supplied_targets):
 def _WriteOutput(params, **values):
   """Writes the output, either to stdout or a file is specified."""
   if 'error' in values:
-    print 'Error:', values['error']
+    print('Error:', values['error'])
   if 'status' in values:
-    print values['status']
+    print(values['status'])
   if 'targets' in values:
     values['targets'].sort()
-    print 'Supplied targets that depend on changed files:'
+    print('Supplied targets that depend on changed files:')
     for target in values['targets']:
-      print '\t', target
+      print('\t', target)
   if 'invalid_targets' in values:
     values['invalid_targets'].sort()
-    print 'The following targets were not found:'
+    print('The following targets were not found:')
     for target in values['invalid_targets']:
-      print '\t', target
+      print('\t', target)
   if 'build_targets' in values:
     values['build_targets'].sort()
-    print 'Targets that require a build:'
+    print('Targets that require a build:')
     for target in values['build_targets']:
-      print '\t', target
+      print('\t', target)
   if 'compile_targets' in values:
     values['compile_targets'].sort()
-    print 'Targets that need to be built:'
+    print('Targets that need to be built:')
     for target in values['compile_targets']:
-      print '\t', target
+      print('\t', target)
   if 'test_targets' in values:
     values['test_targets'].sort()
-    print 'Test targets:'
+    print('Test targets:')
     for target in values['test_targets']:
-      print '\t', target
+      print('\t', target)
 
   output_path = params.get('generator_flags', {}).get(
       'analyzer_output_path', None)
   if not output_path:
-    print json.dumps(values)
+    print(json.dumps(values))
     return
   try:
     f = open(output_path, 'w')
     f.write(json.dumps(values) + '\n')
     f.close()
   except IOError as e:
-    print 'Error writing to output file', output_path, str(e)
+    print('Error writing to output file', output_path, str(e))
 
 
 def _WasGypIncludeFileModified(params, files):
@@ -556,7 +557,7 @@ def _WasGypIncludeFileModified(params, files):
   if params['options'].includes:
     for include in params['options'].includes:
       if _ToGypPath(os.path.normpath(include)) in files:
-        print 'Include file modified, assuming all changed', include
+        print('Include file modified, assuming all changed', include)
         return True
   return False
 
@@ -638,13 +639,13 @@ class TargetCalculator(object):
                                   set(self._root_targets))]
     else:
       test_targets = [x for x in test_targets_no_all]
-    print 'supplied test_targets'
+    print('supplied test_targets')
     for target_name in self._test_target_names:
-      print '\t', target_name
-    print 'found test_targets'
+      print('\t', target_name)
+    print('found test_targets')
     for target in test_targets:
-      print '\t', target.name
-    print 'searching for matching test targets'
+      print('\t', target.name)
+    print('searching for matching test targets')
     matching_test_targets = _GetTargetsDependingOnMatchingTargets(test_targets)
     matching_test_targets_contains_all = (test_target_names_contains_all and
                                           set(matching_test_targets) &
@@ -654,14 +655,14 @@ class TargetCalculator(object):
       # 'all' is subsequentely added to the matching names below.
       matching_test_targets = [x for x in (set(matching_test_targets) &
                                            set(test_targets_no_all))]
-    print 'matched test_targets'
+    print('matched test_targets')
     for target in matching_test_targets:
-      print '\t', target.name
+      print('\t', target.name)
     matching_target_names = [gyp.common.ParseQualifiedTarget(target.name)[1]
                              for target in matching_test_targets]
     if matching_test_targets_contains_all:
       matching_target_names.append('all')
-      print '\tall'
+      print('\tall')
     return matching_target_names
 
   def find_matching_compile_target_names(self):
@@ -677,10 +678,10 @@ class TargetCalculator(object):
     if 'all' in self._supplied_target_names():
       supplied_targets = [x for x in (set(supplied_targets) |
                                       set(self._root_targets))]
-    print 'Supplied test_targets & compile_targets'
+    print('Supplied test_targets & compile_targets')
     for target in supplied_targets:
-      print '\t', target.name
-    print 'Finding compile targets'
+      print('\t', target.name)
+    print('Finding compile targets')
     compile_targets = _GetCompileTargets(self._changed_targets,
                                          supplied_targets)
     return [gyp.common.ParseQualifiedTarget(target.name)[1]
@@ -699,7 +700,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
 
     toplevel_dir = _ToGypPath(os.path.abspath(params['options'].toplevel_dir))
     if debug:
-      print 'toplevel_dir', toplevel_dir
+      print('toplevel_dir', toplevel_dir)
 
     if _WasGypIncludeFileModified(params, config.files):
       result_dict = { 'status': all_changed_string,

--- a/pylib/gyp/generator/cmake.py
+++ b/pylib/gyp/generator/cmake.py
@@ -27,6 +27,7 @@ When using with kdevelop, use version 4.4+. Previous versions of kdevelop will
 not be able to find the header file directories described in the generated
 CMakeLists.txt file.
 """
+from __future__ import print_function
 
 import multiprocessing
 import os
@@ -868,8 +869,8 @@ def WriteTarget(namer, qualified_target, target_dicts, build_dir, config_to_use,
       default_product_ext = generator_default_variables['SHARED_LIB_SUFFIX']
 
     elif target_type != 'executable':
-      print ('ERROR: What output file should be generated?',
-              'type', target_type, 'target', target_name)
+      print(('ERROR: What output file should be generated?',
+              'type', target_type, 'target', target_name))
 
     product_prefix = spec.get('product_prefix', default_product_prefix)
     product_name = spec.get('product_name', default_product_name)
@@ -1207,11 +1208,11 @@ def PerformBuild(data, configurations, params):
                                               output_dir,
                                               config_name))
     arguments = ['cmake', '-G', 'Ninja']
-    print 'Generating [%s]: %s' % (config_name, arguments)
+    print('Generating [%s]: %s' % (config_name, arguments))
     subprocess.check_call(arguments, cwd=build_dir)
 
     arguments = ['ninja', '-C', build_dir]
-    print 'Building [%s]: %s' % (config_name, arguments)
+    print('Building [%s]: %s' % (config_name, arguments))
     subprocess.check_call(arguments)
 
 
@@ -1239,7 +1240,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
           arglists.append((target_list, target_dicts, data,
                            params, config_name))
           pool.map(CallGenerateOutputForConfig, arglists)
-      except KeyboardInterrupt, e:
+      except KeyboardInterrupt as e:
         pool.terminate()
         raise e
     else:

--- a/pylib/gyp/generator/dump_dependency_json.py
+++ b/pylib/gyp/generator/dump_dependency_json.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -96,4 +97,4 @@ def GenerateOutput(target_list, target_dicts, data, params):
   f = open(filename, 'w')
   json.dump(edges, f)
   f.close()
-  print 'Wrote json to %s.' % filename
+  print('Wrote json to %s.' % filename)

--- a/pylib/gyp/generator/eclipse.py
+++ b/pylib/gyp/generator/eclipse.py
@@ -141,7 +141,7 @@ def GetAllIncludeDirectories(target_list, target_dicts,
             compiler_includes_list.append(include_dir)
 
       # Find standard gyp include dirs.
-      if config.has_key('include_dirs'):
+      if 'include_dirs' in config:
         include_dirs = config['include_dirs']
         for shared_intermediate_dir in shared_intermediate_dirs:
           for include_dir in include_dirs:
@@ -156,8 +156,7 @@ def GetAllIncludeDirectories(target_list, target_dicts,
             gyp_includes_set.add(include_dir)
 
   # Generate a list that has all the include dirs.
-  all_includes_list = list(gyp_includes_set)
-  all_includes_list.sort()
+  all_includes_list = sorted(gyp_includes_set)
   for compiler_include in compiler_includes_list:
     if not compiler_include in gyp_includes_set:
       all_includes_list.append(compiler_include)

--- a/pylib/gyp/generator/make.py
+++ b/pylib/gyp/generator/make.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2013 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -1377,8 +1378,8 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
     elif self.type == 'none':
       target = '%s.stamp' % target
     elif self.type != 'executable':
-      print ("ERROR: What output file should be generated?",
-             "type", self.type, "target", target)
+      print(("ERROR: What output file should be generated?",
+             "type", self.type, "target", target))
 
     target_prefix = spec.get('product_prefix', target_prefix)
     target = spec.get('product_name', target)
@@ -1634,7 +1635,7 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
       self.WriteDoCmd([self.output_binary], deps, 'touch', part_of_all,
                       postbuilds=postbuilds)
     else:
-      print "WARNING: no output for", self.type, target
+      print("WARNING: no output for", self.type, target)
 
     # Add an alias for each target (if there are any outputs).
     # Installable target aliases are created below.
@@ -1986,7 +1987,7 @@ def PerformBuild(data, configurations, params):
     if options.toplevel_dir and options.toplevel_dir != '.':
       arguments += '-C', options.toplevel_dir
     arguments.append('BUILDTYPE=' + config)
-    print 'Building [%s]: %s' % (config, arguments)
+    print('Building [%s]: %s' % (config, arguments))
     subprocess.check_call(arguments)
 
 

--- a/pylib/gyp/generator/msvs.py
+++ b/pylib/gyp/generator/msvs.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -252,7 +253,7 @@ def _ToolAppend(tools, tool_name, setting, value, only_if_unset=False):
 def _ToolSetOrAppend(tools, tool_name, setting, value, only_if_unset=False):
   # TODO(bradnelson): ugly hack, fix this more generally!!!
   if 'Directories' in setting or 'Dependencies' in setting:
-    if type(value) == str:
+    if isinstance(value, str):
       value = value.replace('/', '\\')
     else:
       value = [i.replace('/', '\\') for i in value]
@@ -263,7 +264,7 @@ def _ToolSetOrAppend(tools, tool_name, setting, value, only_if_unset=False):
     return
   if tool.get(setting):
     if only_if_unset: return
-    if type(tool[setting]) == list and type(value) == list:
+    if isinstance(tool[setting], list) and isinstance(value, list):
       tool[setting] += value
     else:
       raise TypeError(
@@ -315,10 +316,10 @@ def _ConfigWindowsTargetPlatformVersion(config_data, version):
       if names:
         return names[0]
       else:
-        print >> sys.stdout, (
+        print((
           'Warning: No include files found for '
           'detected Windows SDK version %s' % (version)
-        )
+        ), file=sys.stdout)
 
 
 def _BuildCommandLineForRuleRaw(spec, cmd, cygwin_shell, has_input_path,
@@ -775,8 +776,8 @@ def _EscapeVCProjCommandLineArgListItem(s):
     # the VCProj but cause the same problem on the final command-line. Moving
     # the item to the end of the list does works, but that's only possible if
     # there's only one such item. Let's just warn the user.
-    print >> sys.stderr, ('Warning: MSVS may misinterpret the odd number of ' +
-                          'quotes in ' + s)
+    print(('Warning: MSVS may misinterpret the odd number of ' +
+                          'quotes in ' + s), file=sys.stderr)
   return s
 
 
@@ -1356,7 +1357,7 @@ def _GetDefines(config):
   """
   defines = []
   for d in config.get('defines', []):
-    if type(d) == list:
+    if isinstance(d, list):
       fd = '='.join([str(dpart) for dpart in d])
     else:
       fd = str(d)
@@ -1396,7 +1397,7 @@ def _ConvertToolsToExpectedForm(tools):
     # Collapse settings with lists.
     settings_fixed = {}
     for setting, value in settings.iteritems():
-      if type(value) == list:
+      if isinstance(value, list):
         if ((tool == 'VCLinkerTool' and
              setting == 'AdditionalDependencies') or
             setting == 'AdditionalOptions'):
@@ -1757,7 +1758,7 @@ def _DictsToFolders(base_path, bucket, flat):
   # Convert to folders recursively.
   children = []
   for folder, contents in bucket.iteritems():
-    if type(contents) == dict:
+    if isinstance(contents, dict):
       folder_children = _DictsToFolders(os.path.join(base_path, folder),
                                         contents, flat)
       if flat:
@@ -1776,11 +1777,11 @@ def _CollapseSingles(parent, node):
   # Recursively explorer the tree of dicts looking for projects which are
   # the sole item in a folder which has the same name as the project. Bring
   # such projects up one level.
-  if (type(node) == dict and
+  if (isinstance(node, dict) and
       len(node) == 1 and
       node.keys()[0] == parent + '.vcproj'):
     return node[node.keys()[0]]
-  if type(node) != dict:
+  if not isinstance(node, dict):
     return node
   for child in node:
     node[child] = _CollapseSingles(child, node[child])
@@ -1798,7 +1799,7 @@ def _GatherSolutionFolders(sln_projects, project_objects, flat):
   # Walk down from the top until we hit a folder that has more than one entry.
   # In practice, this strips the top-level "src/" dir from the hierarchy in
   # the solution.
-  while len(root) == 1 and type(root[root.keys()[0]]) == dict:
+  while len(root) == 1 and isinstance(root[root.keys()[0]], dict):
     root = root[root.keys()[0]]
   # Collapse singles.
   root = _CollapseSingles('', root)
@@ -1977,7 +1978,7 @@ def PerformBuild(data, configurations, params):
 
   for config in configurations:
     arguments = [devenv, sln_path, '/Build', config]
-    print 'Building [%s]: %s' % (config, arguments)
+    print('Building [%s]: %s' % (config, arguments))
     rtn = subprocess.check_call(arguments)
 
 
@@ -2072,7 +2073,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
     if generator_flags.get('msvs_error_on_missing_sources', False):
       raise GypError(error_message)
     else:
-      print >> sys.stdout, "Warning: " + error_message
+      print("Warning: " + error_message, file=sys.stdout)
 
 
 def _GenerateMSBuildFiltersFile(filters_path, source_files,
@@ -2778,7 +2779,7 @@ def _GetMSBuildPropertySheets(configurations):
   props_specified = False
   for name, settings in sorted(configurations.iteritems()):
     configuration = _GetConfigurationCondition(name, settings)
-    if settings.has_key('msbuild_props'):
+    if 'msbuild_props' in settings:
       additional_props[configuration] = _FixPaths(settings['msbuild_props'])
       props_specified = True
     else:
@@ -2831,7 +2832,7 @@ def _ConvertMSVSBuildAttributes(spec, config, build_file):
     elif a == 'ConfigurationType':
       msbuild_attributes[a] = _ConvertMSVSConfigurationType(msvs_attributes[a])
     else:
-      print 'Warning: Do not know how to convert MSVS attribute ' + a
+      print('Warning: Do not know how to convert MSVS attribute ' + a)
   return msbuild_attributes
 
 
@@ -3148,7 +3149,7 @@ def _FinalizeMSBuildSettings(spec, configuration):
 
 
 def _GetValueFormattedForMSBuild(tool_name, name, value):
-  if type(value) == list:
+  if isinstance(value, list):
     # For some settings, VS2010 does not automatically extends the settings
     # TODO(jeanluc) Is this what we want?
     if name in ['AdditionalIncludeDirectories',

--- a/pylib/gyp/generator/ninja.py
+++ b/pylib/gyp/generator/ninja.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2013 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -455,8 +456,8 @@ class NinjaWriter(object):
     try:
       sources = extra_sources + spec.get('sources', [])
     except TypeError:
-      print 'extra_sources: ', str(extra_sources)
-      print 'spec.get("sources"): ', str(spec.get('sources'))
+      print('extra_sources: ', str(extra_sources))
+      print('spec.get("sources"): ', str(spec.get('sources')))
       raise
     if sources:
       if self.flavor == 'mac' and len(self.archs) > 1:
@@ -485,8 +486,8 @@ class NinjaWriter(object):
         if self.flavor != 'mac' or len(self.archs) == 1:
           link_deps += [self.GypPathToNinja(o) for o in obj_outputs]
         else:
-          print "Warning: Actions/rules writing object files don't work with " \
-                "multiarch targets, dropping. (target %s)" % spec['target_name']
+          print("Warning: Actions/rules writing object files don't work with " \
+                "multiarch targets, dropping. (target %s)" % spec['target_name'])
     elif self.flavor == 'mac' and len(self.archs) > 1:
       link_deps = collections.defaultdict(list)
 
@@ -2447,7 +2448,7 @@ def PerformBuild(data, configurations, params):
   for config in configurations:
     builddir = os.path.join(options.toplevel_dir, 'out', config)
     arguments = ['ninja', '-C', builddir]
-    print 'Building [%s]: %s' % (config, arguments)
+    print('Building [%s]: %s' % (config, arguments))
     subprocess.check_call(arguments)
 
 
@@ -2484,7 +2485,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
           arglists.append(
               (target_list, target_dicts, data, params, config_name))
         pool.map(CallGenerateOutputForConfig, arglists)
-      except KeyboardInterrupt, e:
+      except KeyboardInterrupt as e:
         pool.terminate()
         raise e
     else:

--- a/pylib/gyp/generator/xcode.py
+++ b/pylib/gyp/generator/xcode.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -129,7 +130,7 @@ class XcodeProject(object):
     try:
       os.makedirs(self.path)
       self.created_dir = True
-    except OSError, e:
+    except OSError as e:
       if e.errno != errno.EEXIST:
         raise
 
@@ -454,7 +455,7 @@ sys.exit(subprocess.call(sys.argv[1:]))" """
       same = False
       try:
         same = filecmp.cmp(pbxproj_path, new_pbxproj_path, False)
-      except OSError, e:
+      except OSError as e:
         if e.errno != errno.ENOENT:
           raise
 
@@ -473,10 +474,10 @@ sys.exit(subprocess.call(sys.argv[1:]))" """
         #
         # No way to get the umask without setting a new one?  Set a safe one
         # and then set it back to the old value.
-        umask = os.umask(077)
+        umask = os.umask(0o77)
         os.umask(umask)
 
-        os.chmod(new_pbxproj_path, 0666 & ~umask)
+        os.chmod(new_pbxproj_path, 0o666 & ~umask)
         os.rename(new_pbxproj_path, pbxproj_path)
 
     except Exception:
@@ -577,7 +578,7 @@ def PerformBuild(data, configurations, params):
   for config in configurations:
     arguments = ['xcodebuild', '-project', xcodeproj_path]
     arguments += ['-configuration', config]
-    print "Building [%s]: %s" % (config, arguments)
+    print("Building [%s]: %s" % (config, arguments))
     subprocess.check_call(arguments)
 
 
@@ -744,7 +745,7 @@ def GenerateOutput(target_list, target_dicts, data, params):
       xctarget_type = gyp.xcodeproj_file.PBXNativeTarget
       try:
         target_properties['productType'] = _types[type_bundle_key]
-      except KeyError, e:
+      except KeyError as e:
         gyp.common.ExceptionAppend(e, "-- unknown product type while "
                                    "writing target %s" % target_name)
         raise

--- a/pylib/gyp/input.py
+++ b/pylib/gyp/input.py
@@ -242,14 +242,14 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
     else:
       build_file_data = eval(build_file_contents, {'__builtins__': None},
                              None)
-  except SyntaxError, e:
+  except SyntaxError as e:
     e.filename = build_file_path
     raise
-  except Exception, e:
+  except Exception as e:
     gyp.common.ExceptionAppend(e, 'while reading ' + build_file_path)
     raise
 
-  if type(build_file_data) is not dict:
+  if not isinstance(build_file_data, dict):
     raise GypError("%s does not evaluate to a dictionary." % build_file_path)
 
   data[build_file_path] = build_file_data
@@ -265,7 +265,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
       else:
         LoadBuildFileIncludesIntoDict(build_file_data, build_file_path, data,
                                       aux_data, None, check)
-    except Exception, e:
+    except Exception as e:
       gyp.common.ExceptionAppend(e,
                                  'while reading includes of ' + build_file_path)
       raise
@@ -303,10 +303,10 @@ def LoadBuildFileIncludesIntoDict(subdict, subdict_path, data, aux_data,
 
   # Recurse into subdictionaries.
   for k, v in subdict.iteritems():
-    if type(v) is dict:
+    if isinstance(v, dict):
       LoadBuildFileIncludesIntoDict(v, subdict_path, data, aux_data,
                                     None, check)
-    elif type(v) is list:
+    elif isinstance(v, list):
       LoadBuildFileIncludesIntoList(v, subdict_path, data, aux_data,
                                     check)
 
@@ -314,10 +314,10 @@ def LoadBuildFileIncludesIntoDict(subdict, subdict_path, data, aux_data,
 # This recurses into lists so that it can look for dicts.
 def LoadBuildFileIncludesIntoList(sublist, sublist_path, data, aux_data, check):
   for item in sublist:
-    if type(item) is dict:
+    if isinstance(item, dict):
       LoadBuildFileIncludesIntoDict(item, sublist_path, data, aux_data,
                                     None, check)
-    elif type(item) is list:
+    elif isinstance(item, list):
       LoadBuildFileIncludesIntoList(item, sublist_path, data, aux_data, check)
 
 # Processes toolsets in all the targets. This recurses into condition entries
@@ -350,9 +350,9 @@ def ProcessToolsetsInDict(data):
     data['targets'] = new_target_list
   if 'conditions' in data:
     for condition in data['conditions']:
-      if type(condition) is list:
+      if isinstance(condition, list):
         for condition_dict in condition[1:]:
-          if type(condition_dict) is dict:
+          if isinstance(condition_dict, dict):
             ProcessToolsetsInDict(condition_dict)
 
 
@@ -467,7 +467,7 @@ def LoadTargetBuildFile(build_file_path, data, aux_data, variables, includes,
       try:
         LoadTargetBuildFile(dependency, data, aux_data, variables,
                             includes, depth, check, load_dependencies)
-      except Exception, e:
+      except Exception as e:
         gyp.common.ExceptionAppend(
           e, 'while loading dependencies of %s' % build_file_path)
         raise
@@ -510,10 +510,10 @@ def CallLoadTargetBuildFile(global_flags,
     return (build_file_path,
             build_file_data,
             dependencies)
-  except GypError, e:
+  except GypError as e:
     sys.stderr.write("gyp: %s\n" % e)
     return None
-  except Exception, e:
+  except Exception as e:
     print >>sys.stderr, 'Exception:', e
     print >>sys.stderr, traceback.format_exc()
     return None
@@ -605,7 +605,7 @@ def LoadTargetBuildFilesParallel(build_files, data, variables, includes, depth,
           args = (global_flags, dependency,
                   variables, includes, depth, check, generator_input_info),
           callback = parallel_state.LoadTargetBuildFileCallback)
-  except KeyboardInterrupt, e:
+  except KeyboardInterrupt as e:
     parallel_state.pool.terminate()
     raise e
 
@@ -648,7 +648,7 @@ def IsStrCanonicalInt(string):
 
   The canonical form is such that str(int(string)) == string.
   """
-  if type(string) is str:
+  if isinstance(string, str):
     # This function is called a lot so for maximum performance, avoid
     # involving regexps which would otherwise make the code much
     # shorter. Regexps would need twice the time of this function.
@@ -695,7 +695,7 @@ cached_command_results = {}
 
 def FixupPlatformCommand(cmd):
   if sys.platform == 'win32':
-    if type(cmd) is list:
+    if isinstance(cmd, list):
       cmd = [re.sub('^cat ', 'type ', cmd[0])] + cmd[1:]
     else:
       cmd = re.sub('^cat ', 'type ', cmd)
@@ -822,7 +822,7 @@ def ExpandVariables(input, phase, variables, build_file):
     # This works around actions/rules which have more inputs than will
     # fit on the command line.
     if file_list:
-      if type(contents) is list:
+      if isinstance(contents, list):
         contents_list = contents
       else:
         contents_list = contents.split(' ')
@@ -905,7 +905,7 @@ def ExpandVariables(input, phase, variables, build_file):
                                  stderr=subprocess.PIPE,
                                  stdin=subprocess.PIPE,
                                  cwd=build_file_dir)
-          except Exception, e:
+          except Exception as e:
             raise GypError("%s while executing command '%s' in %s" %
                            (e, contents, build_file))
 
@@ -945,7 +945,7 @@ def ExpandVariables(input, phase, variables, build_file):
       else:
         replacement = variables[contents]
 
-    if type(replacement) is list:
+    if isinstance(replacement, list):
       for item in replacement:
         if not contents[-1] == '/' and type(item) not in (str, int):
           raise GypError('Variable ' + contents +
@@ -966,7 +966,7 @@ def ExpandVariables(input, phase, variables, build_file):
       # Expanding in list context.  It's guaranteed that there's only one
       # replacement to do in |input_str| and that it's this replacement.  See
       # above.
-      if type(replacement) is list:
+      if isinstance(replacement, list):
         # If it's already a list, make a copy.
         output = replacement[:]
       else:
@@ -975,7 +975,7 @@ def ExpandVariables(input, phase, variables, build_file):
     else:
       # Expanding in string context.
       encoded_replacement = ''
-      if type(replacement) is list:
+      if isinstance(replacement, list):
         # When expanding a list into string context, turn the list items
         # into a string in a way that will work with a subprocess call.
         #
@@ -1003,8 +1003,8 @@ def ExpandVariables(input, phase, variables, build_file):
     # expanding local variables (variables defined in the same
     # variables block as this one).
     gyp.DebugOutput(gyp.DEBUG_VARIABLES, "Found output %r, recursing.", output)
-    if type(output) is list:
-      if output and type(output[0]) is list:
+    if isinstance(output, list):
+      if output and isinstance(output[0], list):
         # Leave output alone if it's a list of lists.
         # We don't want such lists to be stringified.
         pass
@@ -1018,7 +1018,7 @@ def ExpandVariables(input, phase, variables, build_file):
       output = ExpandVariables(output, phase, variables, build_file)
 
   # Convert all strings that are canonically-represented integers into integers.
-  if type(output) is list:
+  if isinstance(output, list):
     for index in xrange(0, len(output)):
       if IsStrCanonicalInt(output[index]):
         output[index] = int(output[index])
@@ -1034,7 +1034,7 @@ cached_conditions_asts = {}
 def EvalCondition(condition, conditions_key, phase, variables, build_file):
   """Returns the dict that should be used or None if the result was
   that nothing should be used."""
-  if type(condition) is not list:
+  if not isinstance(condition, list):
     raise GypError(conditions_key + ' must be a list')
   if len(condition) < 2:
     # It's possible that condition[0] won't work in which case this
@@ -1047,10 +1047,10 @@ def EvalCondition(condition, conditions_key, phase, variables, build_file):
   while i < len(condition):
     cond_expr = condition[i]
     true_dict = condition[i + 1]
-    if type(true_dict) is not dict:
+    if not isinstance(true_dict, dict):
       raise GypError('{} {} must be followed by a dictionary, not {}'.format(
         conditions_key, cond_expr, type(true_dict)))
-    if len(condition) > i + 2 and type(condition[i + 2]) is dict:
+    if len(condition) > i + 2 and isinstance(condition[i + 2], dict):
       false_dict = condition[i + 2]
       i = i + 3
       if i != len(condition):
@@ -1090,13 +1090,13 @@ def EvalSingleCondition(
     if eval(ast_code, {'__builtins__': None}, variables):
       return true_dict
     return false_dict
-  except SyntaxError, e:
+  except SyntaxError as e:
     syntax_error = SyntaxError('%s while evaluating condition \'%s\' in %s '
                                'at character %d.' %
                                (str(e.args[0]), e.text, build_file, e.offset),
                                e.filename, e.lineno, e.offset, e.text)
     raise syntax_error
-  except NameError, e:
+  except NameError as e:
     gyp.common.ExceptionAppend(e, 'while evaluating condition \'%s\' in %s' %
                                (cond_expr_expanded, build_file))
     raise GypError(e)
@@ -1218,7 +1218,7 @@ def ProcessVariablesAndConditionsInDict(the_dict, phase, variables_in,
 
   for key, value in the_dict.iteritems():
     # Skip "variables", which was already processed if present.
-    if key != 'variables' and type(value) is str:
+    if key != 'variables' and isinstance(value, str):
       expanded = ExpandVariables(value, phase, variables, build_file)
       if type(expanded) not in (str, int):
         raise ValueError(
@@ -1277,21 +1277,21 @@ def ProcessVariablesAndConditionsInDict(the_dict, phase, variables_in,
   for key, value in the_dict.iteritems():
     # Skip "variables" and string values, which were already processed if
     # present.
-    if key == 'variables' or type(value) is str:
+    if key == 'variables' or isinstance(value, str):
       continue
-    if type(value) is dict:
+    if isinstance(value, dict):
       # Pass a copy of the variables dict so that subdicts can't influence
       # parents.
       ProcessVariablesAndConditionsInDict(value, phase, variables,
                                           build_file, key)
-    elif type(value) is list:
+    elif isinstance(value, list):
       # The list itself can't influence the variables dict, and
       # ProcessVariablesAndConditionsInList will make copies of the variables
       # dict if it needs to pass it to something that can influence it.  No
       # copy is necessary here.
       ProcessVariablesAndConditionsInList(value, phase, variables,
                                           build_file)
-    elif type(value) is not int:
+    elif not isinstance(value, int):
       raise TypeError('Unknown type ' + value.__class__.__name__ + \
                       ' for ' + key)
 
@@ -1302,17 +1302,17 @@ def ProcessVariablesAndConditionsInList(the_list, phase, variables,
   index = 0
   while index < len(the_list):
     item = the_list[index]
-    if type(item) is dict:
+    if isinstance(item, dict):
       # Make a copy of the variables dict so that it won't influence anything
       # outside of its own scope.
       ProcessVariablesAndConditionsInDict(item, phase, variables, build_file)
-    elif type(item) is list:
+    elif isinstance(item, list):
       ProcessVariablesAndConditionsInList(item, phase, variables, build_file)
-    elif type(item) is str:
+    elif isinstance(item, str):
       expanded = ExpandVariables(item, phase, variables, build_file)
       if type(expanded) in (str, int):
         the_list[index] = expanded
-      elif type(expanded) is list:
+      elif isinstance(expanded, list):
         the_list[index:index+1] = expanded
         index += len(expanded)
 
@@ -1324,7 +1324,7 @@ def ProcessVariablesAndConditionsInList(the_list, phase, variables,
               'Variable expansion in this context permits strings and ' + \
               'lists only, found ' + expanded.__class__.__name__ + ' at ' + \
               index)
-    elif type(item) is not int:
+    elif not isinstance(item, int):
       raise TypeError('Unknown type ' + item.__class__.__name__ + \
                       ' at index ' + index)
     index = index + 1
@@ -1857,7 +1857,7 @@ def VerifyNoGYPFileCircularDependencies(targets):
     for dependency in target_dependencies:
       try:
         dependency_build_file = gyp.common.BuildFile(dependency)
-      except GypError, e:
+      except GypError as e:
         gyp.common.ExceptionAppend(
             e, 'while computing dependencies of .gyp file %s' % build_file)
         raise
@@ -2066,18 +2066,18 @@ def MergeLists(to, fro, to_file, fro_file, is_paths=False, append=True):
       else:
         to_item = item
 
-      if not (type(item) is str and item.startswith('-')):
+      if not (isinstance(item, str) and item.startswith('-')):
         # Any string that doesn't begin with a "-" is a singleton - it can
         # only appear once in a list, to be enforced by the list merge append
         # or prepend.
         singleton = True
-    elif type(item) is dict:
+    elif isinstance(item, dict):
       # Make a copy of the dictionary, continuing to look for paths to fix.
       # The other intelligent aspects of merge processing won't apply because
       # item is being merged into an empty dict.
       to_item = {}
       MergeDicts(to_item, item, to_file, fro_file)
-    elif type(item) is list:
+    elif isinstance(item, list):
       # Recurse, making a copy of the list.  If the list contains any
       # descendant dicts, path fixing will occur.  Note that here, custom
       # values for is_paths and append are dropped; those are only to be
@@ -2126,7 +2126,7 @@ def MergeDicts(to, fro, to_file, fro_file):
       if type(v) in (str, int):
         if type(to[k]) not in (str, int):
           bad_merge = True
-      elif type(v) is not type(to[k]):
+      elif not isinstance(v, type(to[k])):
         bad_merge = True
 
       if bad_merge:
@@ -2141,12 +2141,12 @@ def MergeDicts(to, fro, to_file, fro_file):
         to[k] = MakePathRelative(to_file, fro_file, v)
       else:
         to[k] = v
-    elif type(v) is dict:
+    elif isinstance(v, dict):
       # Recurse, guaranteeing copies will be made of objects that require it.
       if not k in to:
         to[k] = {}
       MergeDicts(to[k], v, to_file, fro_file)
-    elif type(v) is list:
+    elif isinstance(v, list):
       # Lists in dicts can be merged with different policies, depending on
       # how the key in the "from" dict (k, the from-key) is written.
       #
@@ -2189,7 +2189,7 @@ def MergeDicts(to, fro, to_file, fro_file):
           # If the key ends in "?", the list will only be merged if it doesn't
           # already exist.
           continue
-        elif type(to[list_base]) is not list:
+        elif not isinstance(to[list_base], list):
           # This may not have been checked above if merging in a list with an
           # extension character.
           raise TypeError(
@@ -2353,7 +2353,7 @@ def ProcessListFiltersInDict(name, the_dict):
     if operation != '!' and operation != '/':
       continue
 
-    if type(value) is not list:
+    if not isinstance(value, list):
       raise ValueError(name + ' key ' + key + ' must be list, not ' + \
                        value.__class__.__name__)
 
@@ -2365,7 +2365,7 @@ def ProcessListFiltersInDict(name, the_dict):
       del_lists.append(key)
       continue
 
-    if type(the_dict[list_key]) is not list:
+    if not isinstance(the_dict[list_key], list):
       value = the_dict[list_key]
       raise ValueError(name + ' key ' + list_key + \
                        ' must be list, not ' + \
@@ -2467,17 +2467,17 @@ def ProcessListFiltersInDict(name, the_dict):
 
   # Now recurse into subdicts and lists that may contain dicts.
   for key, value in the_dict.iteritems():
-    if type(value) is dict:
+    if isinstance(value, dict):
       ProcessListFiltersInDict(key, value)
-    elif type(value) is list:
+    elif isinstance(value, list):
       ProcessListFiltersInList(key, value)
 
 
 def ProcessListFiltersInList(name, the_list):
   for item in the_list:
-    if type(item) is dict:
+    if isinstance(item, dict):
       ProcessListFiltersInDict(name, item)
-    elif type(item) is list:
+    elif isinstance(item, list):
       ProcessListFiltersInList(name, item)
 
 
@@ -2597,7 +2597,7 @@ def ValidateRunAsInTarget(target, target_dict, build_file):
   run_as = target_dict.get('run_as')
   if not run_as:
     return
-  if type(run_as) is not dict:
+  if not isinstance(run_as, dict):
     raise GypError("The 'run_as' in target %s from file %s should be a "
                    "dictionary." %
                    (target_name, build_file))
@@ -2606,17 +2606,17 @@ def ValidateRunAsInTarget(target, target_dict, build_file):
     raise GypError("The 'run_as' in target %s from file %s must have an "
                    "'action' section." %
                    (target_name, build_file))
-  if type(action) is not list:
+  if not isinstance(action, list):
     raise GypError("The 'action' for 'run_as' in target %s from file %s "
                    "must be a list." %
                    (target_name, build_file))
   working_directory = run_as.get('working_directory')
-  if working_directory and type(working_directory) is not str:
+  if working_directory and not isinstance(working_directory, str):
     raise GypError("The 'working_directory' for 'run_as' in target %s "
                    "in file %s should be a string." %
                    (target_name, build_file))
   environment = run_as.get('environment')
-  if environment and type(environment) is not dict:
+  if environment and not isinstance(environment, dict):
     raise GypError("The 'environment' for 'run_as' in target %s "
                    "in file %s should be a dictionary." %
                    (target_name, build_file))
@@ -2646,15 +2646,15 @@ def TurnIntIntoStrInDict(the_dict):
   # Use items instead of iteritems because there's no need to try to look at
   # reinserted keys and their associated values.
   for k, v in the_dict.items():
-    if type(v) is int:
+    if isinstance(v, int):
       v = str(v)
       the_dict[k] = v
-    elif type(v) is dict:
+    elif isinstance(v, dict):
       TurnIntIntoStrInDict(v)
-    elif type(v) is list:
+    elif isinstance(v, list):
       TurnIntIntoStrInList(v)
 
-    if type(k) is int:
+    if isinstance(k, int):
       del the_dict[k]
       the_dict[str(k)] = v
 
@@ -2664,11 +2664,11 @@ def TurnIntIntoStrInList(the_list):
   """
   for index in xrange(0, len(the_list)):
     item = the_list[index]
-    if type(item) is int:
+    if isinstance(item, int):
       the_list[index] = str(item)
-    elif type(item) is dict:
+    elif isinstance(item, dict):
       TurnIntIntoStrInDict(item)
-    elif type(item) is list:
+    elif isinstance(item, list):
       TurnIntIntoStrInList(item)
 
 
@@ -2780,7 +2780,7 @@ def Load(build_files, variables, includes, depth, generator_input_info, check,
       try:
         LoadTargetBuildFile(build_file, data, aux_data,
                             variables, includes, depth, check, True)
-      except Exception, e:
+      except Exception as e:
         gyp.common.ExceptionAppend(e, 'while trying to load %s' % build_file)
         raise
 

--- a/pylib/gyp/mac_tool.py
+++ b/pylib/gyp/mac_tool.py
@@ -667,7 +667,7 @@ def WriteHmap(output_name, filelist):
   count = len(filelist)
   capacity = NextGreaterPowerOf2(count)
   strings_offset = 24 + (12 * capacity)
-  max_value_length = len(max(filelist.items(), key=lambda (k,v):len(v))[1])
+  max_value_length = len(max(filelist.items(), key=lambda k_v:len(k_v[1]))[1])
 
   out = open(output_name, "wb")
   out.write(struct.pack('<LHHLLLL', magic, version, _reserved, strings_offset,

--- a/pylib/gyp/win_tool.py
+++ b/pylib/gyp/win_tool.py
@@ -8,6 +8,7 @@
 
 These functions are executed via gyp-win-tool when using the ninja generator.
 """
+from __future__ import print_function
 
 import os
 import re
@@ -134,7 +135,7 @@ class WinTool(object):
       if (not line.startswith('   Creating library ') and
           not line.startswith('Generating code') and
           not line.startswith('Finished generating code')):
-        print line
+        print(line)
     return link.returncode
 
   def ExecLinkWithManifests(self, arch, embed_manifest, out, ldcmd, resname,
@@ -223,7 +224,7 @@ class WinTool(object):
     out, _ = popen.communicate()
     for line in out.splitlines():
       if line and 'manifest authoring warning 81010002' not in line:
-        print line
+        print(line)
     return popen.returncode
 
   def ExecManifestToRc(self, arch, *args):
@@ -263,7 +264,7 @@ class WinTool(object):
                      for x in lines if x.startswith(prefixes))
     for line in lines:
       if not line.startswith(prefixes) and line not in processing:
-        print line
+        print(line)
     return popen.returncode
 
   def ExecAsmWrapper(self, arch, *args):
@@ -277,7 +278,7 @@ class WinTool(object):
           not line.startswith('Microsoft (R) Macro Assembler') and
           not line.startswith(' Assembling: ') and
           line):
-        print line
+        print(line)
     return popen.returncode
 
   def ExecRcWrapper(self, arch, *args):
@@ -291,7 +292,7 @@ class WinTool(object):
       if (not line.startswith('Microsoft (R) Windows (R) Resource Compiler') and
           not line.startswith('Copyright (C) Microsoft Corporation') and
           line):
-        print line
+        print(line)
     return popen.returncode
 
   def ExecActionWrapper(self, arch, rspfile, *dir):

--- a/pylib/gyp/xcode_emulation.py
+++ b/pylib/gyp/xcode_emulation.py
@@ -6,6 +6,7 @@
 This module contains classes that help to emulate xcodebuild behavior on top of
 other build systems, such as make and ninja.
 """
+from __future__ import print_function
 
 import copy
 import gyp.common
@@ -73,7 +74,7 @@ class XcodeArchsDefault(object):
             if arch not in expanded_archs:
               expanded_archs.append(arch)
         except KeyError as e:
-          print 'Warning: Ignoring unsupported variable "%s".' % variable
+          print('Warning: Ignoring unsupported variable "%s".' % variable)
       elif arch not in expanded_archs:
         expanded_archs.append(arch)
     return expanded_archs
@@ -197,8 +198,8 @@ class XcodeSettings(object):
           new_key = key.split("[")[0]
           settings[new_key] = settings[key]
       else:
-        print 'Warning: Conditional keys not implemented, ignoring:', \
-              ' '.join(conditional_keys)
+        print('Warning: Conditional keys not implemented, ignoring:', \
+              ' '.join(conditional_keys))
       del settings[key]
 
   def _Settings(self):
@@ -216,7 +217,7 @@ class XcodeSettings(object):
 
   def _WarnUnimplemented(self, test_key):
     if test_key in self._Settings():
-      print 'Warning: Ignoring not yet implemented key "%s".' % test_key
+      print('Warning: Ignoring not yet implemented key "%s".' % test_key)
 
   def IsBinaryOutputFormat(self, configname):
     default = "binary" if self.isIOS else "xml"
@@ -1084,8 +1085,8 @@ class XcodeSettings(object):
     unimpl = ['OTHER_CODE_SIGN_FLAGS']
     unimpl = set(unimpl) & set(self.xcode_settings[configname].keys())
     if unimpl:
-      print 'Warning: Some codesign keys not implemented, ignoring: %s' % (
-          ', '.join(sorted(unimpl)))
+      print('Warning: Some codesign keys not implemented, ignoring: %s' % (
+          ', '.join(sorted(unimpl))))
 
     if self._IsXCTest():
       # For device xctests, Xcode copies two extra frameworks into $TEST_HOST.
@@ -1737,7 +1738,7 @@ def _TopologicallySortedEnvVarKeys(env):
     order = gyp.common.TopologicallySorted(env.keys(), GetEdges)
     order.reverse()
     return order
-  except gyp.common.CycleError, e:
+  except gyp.common.CycleError as e:
     raise GypError(
         'Xcode environment variables are cyclically dependent: ' + str(e.nodes))
 

--- a/pylib/gyp/xcode_emulation.py
+++ b/pylib/gyp/xcode_emulation.py
@@ -1403,16 +1403,16 @@ def XcodeVersion():
   except:
     version = CLTVersion()
     if version:
-      version = re.match(r'(\d\.\d\.?\d*)', version).groups()[0]
+      version = re.search(r'^(\d{1,2}\.\d(\.\d+)?)', version).groups()[0]
     else:
       raise GypError("No Xcode or CLT version detected!")
     # The CLT has no build information, so we return an empty string.
     version_list = [version, '']
   version = version_list[0]
   build = version_list[-1]
-  # Be careful to convert "4.2" to "0420":
-  version = version.split()[-1].replace('.', '')
-  version = (version + '0' * (3 - len(version))).zfill(4)
+  # Be careful to convert "4.2" to "0420" and "10.0" to "1000":
+  version = format(''.join((version.split()[-1].split('.') + ['0', '0'])[:3]),
+                   '>04s')
   if build:
     build = build.split()[-1]
   XCODE_VERSION_CACHE = (version, build)

--- a/pylib/gyp/xcode_ninja.py
+++ b/pylib/gyp/xcode_ninja.py
@@ -28,7 +28,7 @@ def _WriteWorkspace(main_gyp, sources_gyp, params):
     workspace_path = os.path.join(options.generator_output, workspace_path)
   try:
     os.makedirs(workspace_path)
-  except OSError, e:
+  except OSError as e:
     if e.errno != errno.EEXIST:
       raise
   output_string = '<?xml version="1.0" encoding="UTF-8"?>\n' + \

--- a/pylib/gyp/xcodeproj_file.py
+++ b/pylib/gyp/xcodeproj_file.py
@@ -691,7 +691,7 @@ class XCObject(object):
           printable_value[0] == '"' and printable_value[-1] == '"':
         printable_value = printable_value[1:-1]
       printable += printable_key + ' = ' + printable_value + ';' + after_kv
-    except TypeError, e:
+    except TypeError as e:
       gyp.common.ExceptionAppend(e,
                                  'while printing key "%s"' % key)
       raise

--- a/pylib/gyp/xml_fix.py
+++ b/pylib/gyp/xml_fix.py
@@ -32,8 +32,7 @@ def _Replacement_writexml(self, writer, indent="", addindent="", newl=""):
   writer.write(indent+"<" + self.tagName)
 
   attrs = self._get_attributes()
-  a_names = attrs.keys()
-  a_names.sort()
+  a_names = sorted(attrs.keys())
 
   for a_name in a_names:
     writer.write(" %s=\"" % a_name)

--- a/test/actions-multiple-outputs-with-dependencies/gyptest-action.py
+++ b/test/actions-multiple-outputs-with-dependencies/gyptest-action.py
@@ -9,6 +9,7 @@ Verifies actions with multiple outputs & dependncies will correctly rebuild.
 
 This is a regression test for crrev.com/1177163002.
 """
+from __future__ import print_function
 
 import TestGyp
 import os
@@ -16,7 +17,7 @@ import sys
 import time
 
 if sys.platform in ('darwin', 'win32'):
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 test = TestGyp.TestGyp()

--- a/test/actions-multiple-outputs/gyptest-multiple-outputs.py
+++ b/test/actions-multiple-outputs/gyptest-multiple-outputs.py
@@ -7,13 +7,14 @@
 """
 Verifies actions with multiple outputs will correctly rebuild.
 """
+from __future__ import print_function
 
 import TestGyp
 import os
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 test = TestGyp.TestGyp()

--- a/test/analyzer/gyptest-analyzer.py
+++ b/test/analyzer/gyptest-analyzer.py
@@ -5,6 +5,7 @@
 
 """Tests for analyzer
 """
+from __future__ import print_function
 
 import json
 import TestGyp
@@ -75,57 +76,57 @@ def EnsureContains(matched=False, compile_targets=set(), test_targets=set()):
   """Verifies output contains |compile_targets|."""
   result = _ReadOutputFileContents()
   if 'error' in result:
-    print 'unexpected error', result.get('error')
+    print('unexpected error', result.get('error'))
     test.fail_test()
 
   if 'invalid_targets' in result:
-    print 'unexpected invalid_targets', result.get('invalid_targets')
+    print('unexpected invalid_targets', result.get('invalid_targets'))
     test.fail_test()
 
   actual_compile_targets = set(result['compile_targets'])
   if actual_compile_targets != compile_targets:
-    print 'actual compile_targets:', actual_compile_targets, \
-           '\nexpected compile_targets:', compile_targets
+    print('actual compile_targets:', actual_compile_targets, \
+           '\nexpected compile_targets:', compile_targets)
     test.fail_test()
 
   actual_test_targets = set(result['test_targets'])
   if actual_test_targets != test_targets:
-    print 'actual test_targets:', actual_test_targets, \
-           '\nexpected test_targets:', test_targets
+    print('actual test_targets:', actual_test_targets, \
+           '\nexpected test_targets:', test_targets)
     test.fail_test()
 
   if matched and result['status'] != found:
-    print 'expected', found, 'got', result['status']
+    print('expected', found, 'got', result['status'])
     test.fail_test()
   elif not matched and result['status'] != not_found:
-    print 'expected', not_found, 'got', result['status']
+    print('expected', not_found, 'got', result['status'])
     test.fail_test()
 
 
 def EnsureMatchedAll(compile_targets, test_targets=set()):
   result = _ReadOutputFileContents()
   if 'error' in result:
-    print 'unexpected error', result.get('error')
+    print('unexpected error', result.get('error'))
     test.fail_test()
 
   if 'invalid_targets' in result:
-    print 'unexpected invalid_targets', result.get('invalid_targets')
+    print('unexpected invalid_targets', result.get('invalid_targets'))
     test.fail_test()
 
   if result['status'] != found_all:
-    print 'expected', found_all, 'got', result['status']
+    print('expected', found_all, 'got', result['status'])
     test.fail_test()
 
   actual_compile_targets = set(result['compile_targets'])
   if actual_compile_targets != compile_targets:
-    print ('actual compile_targets:', actual_compile_targets,
-           '\nexpected compile_targets:', compile_targets)
+    print(('actual compile_targets:', actual_compile_targets,
+           '\nexpected compile_targets:', compile_targets))
     test.fail_test()
 
   actual_test_targets = set(result['test_targets'])
   if actual_test_targets != test_targets:
-    print ('actual test_targets:', actual_test_targets,
-           '\nexpected test_targets:', test_targets)
+    print(('actual test_targets:', actual_test_targets,
+           '\nexpected test_targets:', test_targets))
     test.fail_test()
 
 
@@ -133,15 +134,15 @@ def EnsureError(expected_error_string):
   """Verifies output contains the error string."""
   result = _ReadOutputFileContents()
   if result.get('error', '').find(expected_error_string) == -1:
-    print 'actual error:', result.get('error', ''), '\nexpected error:', \
-        expected_error_string
+    print('actual error:', result.get('error', ''), '\nexpected error:', \
+        expected_error_string)
     test.fail_test()
 
 
 def EnsureStdoutContains(expected_error_string):
   if test.stdout().find(expected_error_string) == -1:
-    print 'actual stdout:', test.stdout(), '\nexpected stdout:', \
-        expected_error_string
+    print('actual stdout:', test.stdout(), '\nexpected stdout:', \
+        expected_error_string)
     test.fail_test()
 
 
@@ -150,8 +151,8 @@ def EnsureInvalidTargets(expected_invalid_targets):
   result = _ReadOutputFileContents()
   actual_invalid_targets = set(result['invalid_targets'])
   if actual_invalid_targets != expected_invalid_targets:
-    print 'actual invalid_targets:', actual_invalid_targets, \
-        '\nexpected :', expected_invalid_targets
+    print('actual invalid_targets:', actual_invalid_targets, \
+        '\nexpected :', expected_invalid_targets)
     test.fail_test()
 
 

--- a/test/arflags/gyptest-arflags.py
+++ b/test/arflags/gyptest-arflags.py
@@ -7,13 +7,14 @@
 """
 Verifies that building a target with invalid arflags fails.
 """
+from __future__ import print_function
 
 import os
 import sys
 import TestGyp
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/compiler-override/gyptest-compiler-global-settings.py
+++ b/test/compiler-override/gyptest-compiler-global-settings.py
@@ -6,6 +6,7 @@
 Verifies that make_global_settings can be used to override the
 compiler settings.
 """
+from __future__ import print_function
 
 import TestGyp
 import os
@@ -19,7 +20,7 @@ if sys.platform == 'win32':
   # and make not supported on windows at all.
   sys.exit(0)
 
-print "This test is currently disabled: https://crbug.com/483696."
+print("This test is currently disabled: https://crbug.com/483696.")
 sys.exit(0)
 
 test = TestGyp.TestGyp(formats=['ninja', 'make'])

--- a/test/compiler-override/my_cc.py
+++ b/test/compiler-override/my_cc.py
@@ -2,5 +2,6 @@
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+from __future__ import print_function
 import sys
-print sys.argv
+print(sys.argv)

--- a/test/compiler-override/my_cxx.py
+++ b/test/compiler-override/my_cxx.py
@@ -2,5 +2,6 @@
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+from __future__ import print_function
 import sys
-print sys.argv
+print(sys.argv)

--- a/test/compiler-override/my_ld.py
+++ b/test/compiler-override/my_ld.py
@@ -2,5 +2,6 @@
 # Copyright (c) 2012 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+from __future__ import print_function
 import sys
-print sys.argv
+print(sys.argv)

--- a/test/compiler-override/my_nm.py
+++ b/test/compiler-override/my_nm.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+from __future__ import print_function
 import sys
-print sys.argv
+print(sys.argv)
 with open('RAN_MY_NM', 'w') as f:
   f.write('RAN_MY_NM')

--- a/test/compiler-override/my_readelf.py
+++ b/test/compiler-override/my_readelf.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+from __future__ import print_function
 import sys
-print sys.argv
+print(sys.argv)
 with open('RAN_MY_READELF', 'w') as f:
   f.write('RAN_MY_READELF')

--- a/test/configurations/inheritance/gyptest-duplicates.py
+++ b/test/configurations/inheritance/gyptest-duplicates.py
@@ -7,6 +7,7 @@
 """
 Verifies that configurations do not duplicate other settings.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -27,7 +28,7 @@ contents = test.read('duplicates.gypd').replace(
     '\r', '').replace('\\\\', '/')
 expect = test.read('duplicates.gypd.golden').replace('\r', '')
 if not test.match(contents, expect):
-  print "Unexpected contents of `duplicates.gypd'"
+  print("Unexpected contents of `duplicates.gypd'")
   test.diff(expect, contents, 'duplicates.gypd ')
   test.fail_test()
 

--- a/test/configurations/target_platform/gyptest-target_platform.py
+++ b/test/configurations/target_platform/gyptest-target_platform.py
@@ -15,7 +15,7 @@ import TestCommon
 def RunX64(exe, stdout):
   try:
     test.run_built_executable(exe, stdout=stdout)
-  except WindowsError, e:
+  except WindowsError as e:
     # Assume the exe is 64-bit if it can't load on 32-bit systems.
     # Both versions of the error are required because different versions
     # of python seem to return different errors for invalid exe type.

--- a/test/copies/gyptest-updir.py
+++ b/test/copies/gyptest-updir.py
@@ -8,13 +8,14 @@
 Verifies file copies where the destination is one level above an expansion that
 yields a make variable.
 """
+from __future__ import print_function
 
 import sys
 
 import TestGyp
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 test = TestGyp.TestGyp()

--- a/test/determinism/gyptest-solibs.py
+++ b/test/determinism/gyptest-solibs.py
@@ -8,6 +8,7 @@
 Verifies builds are the same even with different PYTHONHASHSEEDs.
 Tests all_targets, implicit_deps and solibs.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -28,7 +29,7 @@ if test.format == 'ninja':
     if base1 != contents1:
       test.fail_test()
     if base2 != contents2:
-      print base2
+      print(base2)
       test.fail_test()
 
   del os.environ["PYTHONHASHSEED"]

--- a/test/determinism/rule.py
+++ b/test/determinism/rule.py
@@ -1,3 +1,4 @@
 #!/usr/bin/env python
 
-print 'Hello World'
+from __future__ import print_function
+print('Hello World')

--- a/test/escaping/gyptest-colon.py
+++ b/test/escaping/gyptest-colon.py
@@ -8,12 +8,13 @@
 Tests that filenames that contain colons are handled correctly.
 (This is important for absolute paths on Windows.)
 """
+from __future__ import print_function
 
 import os
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/generator-output/gyptest-mac-bundle.py
+++ b/test/generator-output/gyptest-mac-bundle.py
@@ -7,13 +7,14 @@
 """
 Verifies mac bundles work with --generator-output.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=[])

--- a/test/ios/gyptest-app-ios.py
+++ b/test/ios/gyptest-app-ios.py
@@ -7,6 +7,7 @@
 """
 Verifies that ios app bundles are built correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -16,13 +17,13 @@ import sys
 def CheckFileXMLPropertyList(file):
   output = subprocess.check_output(['file', file])
   if not 'XML 1.0 document text' in output:
-    print 'File: Expected XML 1.0 document text, got %s' % output
+    print('File: Expected XML 1.0 document text, got %s' % output)
     test.fail_test()
 
 def CheckFileBinaryPropertyList(file):
   output = subprocess.check_output(['file', file])
   if not 'Apple binary property list' in output:
-    print 'File: Expected Apple binary property list, got %s' % output
+    print('File: Expected Apple binary property list, got %s' % output)
     test.fail_test()
 
 if sys.platform == 'darwin':

--- a/test/ios/gyptest-extension.py
+++ b/test/ios/gyptest-extension.py
@@ -7,6 +7,7 @@
 """
 Verifies that ios app extensions are built correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 import TestMac
@@ -15,12 +16,12 @@ import sys
 
 def CheckStrip(p, expected):
   if expected not in subprocess.check_output(['nm','-gU', p]):
-    print expected + " shouldn't get stripped out."
+    print(expected + " shouldn't get stripped out.")
     test.fail_test()
 
 def CheckEntrypoint(p, expected):
   if expected not in subprocess.check_output(['nm', p]):
-    print expected + "not found."
+    print(expected + "not found.")
     test.fail_test()
 
 if sys.platform == 'darwin' and TestMac.Xcode.Version()>="0600":

--- a/test/ios/gyptest-per-config-settings.py
+++ b/test/ios/gyptest-per-config-settings.py
@@ -7,6 +7,7 @@
 """
 Verifies that device and simulator bundles are built correctly.
 """
+from __future__ import print_function
 
 import plistlib
 import TestGyp
@@ -17,7 +18,7 @@ import sys
 import tempfile
 import TestMac
 
-print "This test is currently disabled: https://crbug.com/483696."
+print("This test is currently disabled: https://crbug.com/483696.")
 sys.exit(0)
 
 def CheckFileType(file, expected):
@@ -25,7 +26,7 @@ def CheckFileType(file, expected):
   o = proc.communicate()[0].strip()
   assert not proc.returncode
   if not expected in o:
-    print 'File: Expected %s, got %s' % (expected, o)
+    print('File: Expected %s, got %s' % (expected, o))
     test.fail_test()
 
 def HasCerts():
@@ -40,7 +41,7 @@ def CheckSignature(file):
   o = proc.communicate()[0].strip()
   assert not proc.returncode
   if "code object is not signed at all" in o:
-    print 'File %s not properly signed.' % (file)
+    print('File %s not properly signed.' % (file))
     test.fail_test()
 
 def CheckEntitlements(file, expected_entitlements):
@@ -52,10 +53,10 @@ def CheckEntitlements(file, expected_entitlements):
     data = temp.read()
   entitlements = ParseEntitlements(data)
   if not entitlements:
-    print 'No valid entitlements found in %s.' % (file)
+    print('No valid entitlements found in %s.' % (file))
     test.fail_test()
   if entitlements != expected_entitlements:
-    print 'Unexpected entitlements found in %s.' % (file)
+    print('Unexpected entitlements found in %s.' % (file))
     test.fail_test()
 
 def ParseEntitlements(data):
@@ -78,17 +79,17 @@ def GetMachineBuild():
 
 def CheckPlistvalue(plist, key, expected):
   if key not in plist:
-    print '%s not set in plist' % key
+    print('%s not set in plist' % key)
     test.fail_test()
     return
   actual = plist[key]
   if actual != expected:
-    print 'File: Expected %s, got %s for %s' % (expected, actual, key)
+    print('File: Expected %s, got %s for %s' % (expected, actual, key))
     test.fail_test()
 
 def CheckPlistNotSet(plist, key):
   if key in plist:
-    print '%s should not be set in plist' % key
+    print('%s should not be set in plist' % key)
     test.fail_test()
     return
 
@@ -114,7 +115,7 @@ if sys.platform == 'darwin':
     xcode_version = TestMac.Xcode.Version()
     if xcode_version >= '0720':
       if len(plist) != 23:
-        print 'plist should have 23 entries, but it has %s' % len(plist)
+        print('plist should have 23 entries, but it has %s' % len(plist))
         test.fail_test()
 
     # Values that will hopefully never change.

--- a/test/ios/gyptest-watch.py
+++ b/test/ios/gyptest-watch.py
@@ -7,6 +7,7 @@
 """
 Verifies that ios watch extensions and apps are built correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 import TestMac
@@ -14,7 +15,7 @@ import TestMac
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/lib/TestCommon.py
+++ b/test/lib/TestCommon.py
@@ -71,6 +71,7 @@ The TestCommon module also provides the following variables
     TestCommon.dll_suffix
 
 """
+from __future__ import print_function
 
 # Copyright 2000-2010 Steven Knight
 # This module is free software, and you may redistribute it and/or modify
@@ -184,7 +185,7 @@ else:
     module_suffix = '.so'
 
 def is_List(e):
-    return type(e) is types.ListType \
+    return isinstance(e, list) \
         or isinstance(e, UserList.UserList)
 
 def is_writable(f):
@@ -227,7 +228,7 @@ class TestCommon(TestCmd):
         calling the base class initialization, and then changing directory
         to the workdir.
         """
-        apply(TestCmd.__init__, [self], kw)
+        TestCmd.__init__(*[self], **kw)
         os.chdir(self.workdir)
 
     def must_be_writable(self, *files):
@@ -237,13 +238,13 @@ class TestCommon(TestCmd):
         them.  Exits FAILED if any of the files does not exist or is
         not writable.
         """
-        files = map(lambda x: is_List(x) and apply(os.path.join, x) or x, files)
+        files = map(lambda x: is_List(x) and os.path.join(*x) or x, files)
         existing, missing = separate_files(files)
         unwritable = filter(lambda x, iw=is_writable: not iw(x), existing)
         if missing:
-            print "Missing files: `%s'" % string.join(missing, "', `")
+            print("Missing files: `%s'" % string.join(missing, "', `"))
         if unwritable:
-            print "Unwritable files: `%s'" % string.join(unwritable, "', `")
+            print("Unwritable files: `%s'" % string.join(unwritable, "', `"))
         self.fail_test(missing + unwritable)
 
     def must_contain(self, file, required, mode = 'rb'):
@@ -252,11 +253,11 @@ class TestCommon(TestCmd):
         file_contents = self.read(file, mode)
         contains = (string.find(file_contents, required) != -1)
         if not contains:
-            print "File `%s' does not contain required string." % file
-            print self.banner('Required string ')
-            print required
-            print self.banner('%s contents ' % file)
-            print file_contents
+            print("File `%s' does not contain required string." % file)
+            print(self.banner('Required string '))
+            print(required)
+            print(self.banner('%s contents ' % file))
+            print(file_contents)
             self.fail_test(not contains)
 
     def must_contain_all_lines(self, output, lines, title=None, find=None):
@@ -323,10 +324,10 @@ class TestCommon(TestCmd):
         pathname will be constructed by concatenating them.  Exits FAILED
         if any of the files does not exist.
         """
-        files = map(lambda x: is_List(x) and apply(os.path.join, x) or x, files)
+        files = map(lambda x: is_List(x) and os.path.join(*x) or x, files)
         missing = filter(lambda x: not os.path.exists(x), files)
         if missing:
-            print "Missing files: `%s'" % string.join(missing, "', `")
+            print("Missing files: `%s'" % string.join(missing, "', `"))
             self.fail_test(missing)
 
     def must_match(self, file, expect, mode = 'rb'):
@@ -341,7 +342,7 @@ class TestCommon(TestCmd):
         except KeyboardInterrupt:
             raise
         except:
-            print "Unexpected contents of `%s'" % file
+            print("Unexpected contents of `%s'" % file)
             self.diff(expect, file_contents, 'contents ')
             raise
 
@@ -351,11 +352,11 @@ class TestCommon(TestCmd):
         file_contents = self.read(file, mode)
         contains = (string.find(file_contents, banned) != -1)
         if contains:
-            print "File `%s' contains banned string." % file
-            print self.banner('Banned string ')
-            print banned
-            print self.banner('%s contents ' % file)
-            print file_contents
+            print("File `%s' contains banned string." % file)
+            print(self.banner('Banned string '))
+            print(banned)
+            print(self.banner('%s contents ' % file))
+            print(file_contents)
             self.fail_test(contains)
 
     def must_not_contain_any_line(self, output, lines, title=None, find=None):
@@ -395,10 +396,10 @@ class TestCommon(TestCmd):
         which case the pathname will be constructed by concatenating them.
         Exits FAILED if any of the files exists.
         """
-        files = map(lambda x: is_List(x) and apply(os.path.join, x) or x, files)
+        files = map(lambda x: is_List(x) and os.path.join(*x) or x, files)
         existing = filter(os.path.exists, files)
         if existing:
-            print "Unexpected files exist: `%s'" % string.join(existing, "', `")
+            print("Unexpected files exist: `%s'" % string.join(existing, "', `"))
             self.fail_test(existing)
 
     def must_not_be_writable(self, *files):
@@ -408,13 +409,13 @@ class TestCommon(TestCmd):
         them.  Exits FAILED if any of the files does not exist or is
         writable.
         """
-        files = map(lambda x: is_List(x) and apply(os.path.join, x) or x, files)
+        files = map(lambda x: is_List(x) and os.path.join(*x) or x, files)
         existing, missing = separate_files(files)
         writable = filter(is_writable, existing)
         if missing:
-            print "Missing files: `%s'" % string.join(missing, "', `")
+            print("Missing files: `%s'" % string.join(missing, "', `"))
         if writable:
-            print "Writable files: `%s'" % string.join(writable, "', `")
+            print("Writable files: `%s'" % string.join(writable, "', `"))
         self.fail_test(missing + writable)
 
     def _complete(self, actual_stdout, expected_stdout,
@@ -427,21 +428,21 @@ class TestCommon(TestCmd):
             expect = ''
             if status != 0:
                 expect = " (expected %s)" % str(status)
-            print "%s returned %s%s" % (self.program, str(_status(self)), expect)
-            print self.banner('STDOUT ')
-            print actual_stdout
-            print self.banner('STDERR ')
-            print actual_stderr
+            print("%s returned %s%s" % (self.program, str(_status(self)), expect))
+            print(self.banner('STDOUT '))
+            print(actual_stdout)
+            print(self.banner('STDERR '))
+            print(actual_stderr)
             self.fail_test()
         if not expected_stdout is None and not match(actual_stdout, expected_stdout):
             self.diff(expected_stdout, actual_stdout, 'STDOUT ')
             if actual_stderr:
-                print self.banner('STDERR ')
-                print actual_stderr
+                print(self.banner('STDERR '))
+                print(actual_stderr)
             self.fail_test()
         if not expected_stderr is None and not match(actual_stderr, expected_stderr):
-            print self.banner('STDOUT ')
-            print actual_stdout
+            print(self.banner('STDOUT '))
+            print(actual_stdout)
             self.diff(expected_stderr, actual_stderr, 'STDERR ')
             self.fail_test()
 
@@ -463,20 +464,18 @@ class TestCommon(TestCmd):
                 arguments = options + " " + arguments
 
         try:
-            return apply(TestCmd.start,
-                         (self, program, interpreter, arguments, universal_newlines),
-                         kw)
+            return TestCmd.start(*(self, program, interpreter, arguments, universal_newlines), **kw)
         except KeyboardInterrupt:
             raise
-        except Exception, e:
-            print self.banner('STDOUT ')
+        except Exception as e:
+            print(self.banner('STDOUT '))
             try:
-                print self.stdout()
+                print(self.stdout())
             except IndexError:
                 pass
-            print self.banner('STDERR ')
+            print(self.banner('STDERR '))
             try:
-                print self.stderr()
+                print(self.stderr())
             except IndexError:
                 pass
             cmd_args = self.command_args(program, interpreter, arguments)
@@ -501,7 +500,7 @@ class TestCommon(TestCmd):
                         command.  A value of None means don't
                         test exit status.
         """
-        apply(TestCmd.finish, (self, popen,), kw)
+        TestCmd.finish(*(self, popen,), **kw)
         match = kw.get('match', self.match)
         self._complete(self.stdout(), stdout,
                        self.stderr(), stderr, status, match)
@@ -539,7 +538,7 @@ class TestCommon(TestCmd):
                 arguments = options + " " + arguments
         kw['arguments'] = arguments
         match = kw.pop('match', self.match)
-        apply(TestCmd.run, [self], kw)
+        TestCmd.run(*[self], **kw)
         self._complete(self.stdout(), stdout,
                        self.stderr(), stderr, status, match)
 

--- a/test/lib/TestGyp.py
+++ b/test/lib/TestGyp.py
@@ -5,6 +5,7 @@
 """
 TestGyp.py:  a testing framework for GYP integration tests.
 """
+from __future__ import print_function
 
 import errno
 import collections
@@ -283,13 +284,13 @@ class TestGypBase(TestCommon.TestCommon):
     that expect exact output from the command (make) can
     just set stdout= when they call the run_build() method.
     """
-    print "Build is not up-to-date:"
-    print self.banner('STDOUT ')
-    print self.stdout()
+    print("Build is not up-to-date:")
+    print(self.banner('STDOUT '))
+    print(self.stdout())
     stderr = self.stderr()
     if stderr:
-      print self.banner('STDERR ')
-      print stderr
+      print(self.banner('STDERR '))
+      print(stderr)
 
   def run_gyp(self, gyp_file, *args, **kw):
     """
@@ -328,7 +329,7 @@ class TestGypBase(TestCommon.TestCommon):
     the tool-specific subclasses or clutter the tests themselves
     with platform-specific code.
     """
-    if kw.has_key('SYMROOT'):
+    if 'SYMROOT' in kw:
       del kw['SYMROOT']
     super(TestGypBase, self).run(*args, **kw)
 
@@ -558,7 +559,7 @@ class TestGypMake(TestGypBase):
     # Makefile.gyp_filename), so use that if there is no Makefile.
     chdir = kw.get('chdir', '')
     if not os.path.exists(os.path.join(chdir, 'Makefile')):
-      print "NO Makefile in " + os.path.join(chdir, 'Makefile')
+      print("NO Makefile in " + os.path.join(chdir, 'Makefile'))
       arguments.insert(0, '-f')
       arguments.insert(1, os.path.splitext(gyp_file)[0] + '.Makefile')
     kw['arguments'] = arguments
@@ -665,7 +666,7 @@ def FindMSBuildInstallation(msvs_version = 'auto'):
 
   msbuild_basekey = r'HKLM\SOFTWARE\Microsoft\MSBuild\ToolsVersions'
   if not registry.KeyExists(msbuild_basekey):
-    print 'Error: could not find MSBuild base registry entry'
+    print('Error: could not find MSBuild base registry entry')
     return None
 
   msbuild_version = None
@@ -684,13 +685,13 @@ def FindMSBuildInstallation(msvs_version = 'auto'):
         msbuild_version = msbuild_test_version
         break
   if not msbuild_version:
-    print 'Error: could not find MSBuild registry entry'
+    print('Error: could not find MSBuild registry entry')
     return None
 
   msbuild_path = registry.GetValue(msbuild_basekey + '\\' + msbuild_version,
                                    'MSBuildToolsPath')
   if not msbuild_path:
-    print 'Error: could not get MSBuild registry entry value'
+    print('Error: could not get MSBuild registry entry value')
     return None
 
   return os.path.join(msbuild_path, 'MSBuild.exe')
@@ -779,7 +780,7 @@ def FindVisualStudioInstallation():
         uses_msbuild = msvs_version >= '2010'
         msbuild_path = FindMSBuildInstallation(msvs_version)
         return build_tool, uses_msbuild, msbuild_path
-  print 'Error: could not find devenv'
+  print('Error: could not find devenv')
   sys.exit(1)
 
 class TestGypOnMSToolchain(TestGypBase):
@@ -1243,4 +1244,4 @@ def TestGyp(*args, **kw):
   for format_class in format_class_list:
     if format == format_class.format:
       return format_class(*args, **kw)
-  raise Exception, "unknown format %r" % format
+  raise Exception("unknown format %r" % format)

--- a/test/lib/TestMac.py
+++ b/test/lib/TestMac.py
@@ -5,6 +5,7 @@
 """
 TestMac.py:  a collection of helper function shared between test on Mac OS X.
 """
+from __future__ import print_function
 
 import re
 import subprocess
@@ -23,13 +24,13 @@ def CheckFileType(test, file, archs):
     pattern = re.compile('^Architectures in the fat file: (.*) are: (.*)$')
   match = pattern.match(o)
   if match is None:
-    print 'Ouput does not match expected pattern: %s' % (pattern.pattern)
+    print('Ouput does not match expected pattern: %s' % (pattern.pattern))
     test.fail_test()
   else:
     found_file, found_archs = match.groups()
     if found_file != file or set(found_archs.split()) != set(archs):
-      print 'Expected file %s with arch %s, got %s with arch %s' % (
-          file, ' '.join(archs), found_file, found_archs)
+      print('Expected file %s with arch %s, got %s with arch %s' % (
+          file, ' '.join(archs), found_file, found_archs))
       test.fail_test()
 
 

--- a/test/lib/TestWin.py
+++ b/test/lib/TestWin.py
@@ -63,7 +63,7 @@ class Registry(object):
     text = None
     try:
       text = self._QueryBase('Sysnative', key, value)
-    except OSError, e:
+    except OSError as e:
       if e.errno == errno.ENOENT:
         text = self._QueryBase('System32', key, value)
       else:

--- a/test/linux/ldflags-duplicates/check-ldflags.py
+++ b/test/linux/ldflags-duplicates/check-ldflags.py
@@ -7,18 +7,19 @@
 """
 Verifies duplicate ldflags are not removed.
 """
+from __future__ import print_function
 
 import sys
 
 def CheckContainsFlags(args, substring):
   if args.find(substring) is -1:
-    print 'ERROR: Linker arguments "%s" are missing in "%s"' % (substring, args)
+    print('ERROR: Linker arguments "%s" are missing in "%s"' % (substring, args))
     return False;
   return True;
 
 if __name__ == '__main__':
   args = " ".join(sys.argv)
-  print  "args = " +args
+  print("args = " +args)
   if not CheckContainsFlags(args, 'lib1.a -Wl,--no-whole-archive') \
     or not CheckContainsFlags(args, 'lib2.a -Wl,--no-whole-archive'):
     sys.exit(1);

--- a/test/mac/gyptest-app-assets-catalog.py
+++ b/test/mac/gyptest-app-assets-catalog.py
@@ -7,6 +7,7 @@
 """
 Verifies that app bundles are built correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 import TestMac
@@ -17,12 +18,12 @@ import subprocess
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 def ExpectEq(expected, actual):
   if expected != actual:
-    print >>sys.stderr, 'Expected "%s", got "%s"' % (expected, actual)
+    print('Expected "%s", got "%s"' % (expected, actual), file=sys.stderr)
     test.fail_test()
 
 def ls(path):

--- a/test/mac/gyptest-app-error.py
+++ b/test/mac/gyptest-app-error.py
@@ -7,6 +7,7 @@
 """
 Verifies that invalid strings files cause the build to fail.
 """
+from __future__ import print_function
 
 import TestCmd
 import TestGyp
@@ -14,7 +15,7 @@ import TestGyp
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   expected_error = 'Old-style plist parser: missing semicolon in dictionary'

--- a/test/mac/gyptest-app.py
+++ b/test/mac/gyptest-app.py
@@ -7,6 +7,7 @@
 """
 Verifies that app bundles are built correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 import TestMac
@@ -18,7 +19,7 @@ import sys
 
 
 if sys.platform in ('darwin', 'win32'):
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 
@@ -26,12 +27,12 @@ def CheckFileXMLPropertyList(file):
   output = subprocess.check_output(['file', file])
   # The double space after XML is intentional.
   if not 'XML  document text' in output:
-    print 'File: Expected XML  document text, got %s' % output
+    print('File: Expected XML  document text, got %s' % output)
     test.fail_test()
 
 def ExpectEq(expected, actual):
   if expected != actual:
-    print >>sys.stderr, 'Expected "%s", got "%s"' % (expected, actual)
+    print('Expected "%s", got "%s"' % (expected, actual), file=sys.stderr)
     test.fail_test()
 
 def ls(path):

--- a/test/mac/gyptest-bundle-resources.py
+++ b/test/mac/gyptest-bundle-resources.py
@@ -7,6 +7,7 @@
 """
 Verifies things related to bundle resources.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -15,7 +16,7 @@ import stat
 import sys
 
 if sys.platform in ('darwin'):
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/mac/gyptest-copies.py
+++ b/test/mac/gyptest-copies.py
@@ -7,6 +7,7 @@
 """
 Verifies that 'copies' with app bundles are handled correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -15,7 +16,7 @@ import sys
 import time
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-depend-on-bundle.py
+++ b/test/mac/gyptest-depend-on-bundle.py
@@ -7,13 +7,14 @@
 """
 Verifies that a dependency on a bundle causes the whole bundle to be built.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-framework.py
+++ b/test/mac/gyptest-framework.py
@@ -7,6 +7,7 @@
 """
 Verifies that app bundles are built correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -14,7 +15,7 @@ import os
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/mac/gyptest-infoplist-process.py
+++ b/test/mac/gyptest-infoplist-process.py
@@ -7,13 +7,14 @@
 """
 Verifies the Info.plist preprocessor functionality.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-installname.py
+++ b/test/mac/gyptest-installname.py
@@ -8,6 +8,7 @@
 Verifies that LD_DYLIB_INSTALL_NAME and DYLIB_INSTALL_NAME_BASE are handled
 correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -16,7 +17,7 @@ import subprocess
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-ldflags-passed-to-libtool.py
+++ b/test/mac/gyptest-ldflags-passed-to-libtool.py
@@ -7,13 +7,14 @@
 """
 Verifies that OTHER_LDFLAGS is passed to libtool.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'],

--- a/test/mac/gyptest-loadable-module.py
+++ b/test/mac/gyptest-loadable-module.py
@@ -7,6 +7,7 @@
 """
 Tests that a loadable_module target is built correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -15,7 +16,7 @@ import struct
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-missing-cfbundlesignature.py
+++ b/test/mac/gyptest-missing-cfbundlesignature.py
@@ -7,13 +7,14 @@
 """
 Verifies that an Info.plist with CFBundleSignature works.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-non-strs-flattened-to-env.py
+++ b/test/mac/gyptest-non-strs-flattened-to-env.py
@@ -8,13 +8,14 @@
 Verifies that list xcode_settings are flattened before being exported to the
 environment.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-postbuild-defaults.py
+++ b/test/mac/gyptest-postbuild-defaults.py
@@ -7,13 +7,14 @@
 """
 Verifies that a postbuild invoking |defaults| works.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-postbuild-fail.py
+++ b/test/mac/gyptest-postbuild-fail.py
@@ -7,6 +7,7 @@
 """
 Verifies that a failing postbuild step lets the build fail.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -39,7 +40,7 @@ if sys.platform == 'darwin':
                          stderr=subprocess.STDOUT)
   out, err = job.communicate()
   if job.returncode != 0:
-    print out
+    print(out)
     raise Exception('Error %d running xcodebuild' % job.returncode)
   if out.startswith('Xcode 3.'):
     test.pass_test()

--- a/test/mac/gyptest-rebuild.py
+++ b/test/mac/gyptest-rebuild.py
@@ -7,13 +7,14 @@
 """
 Verifies that app bundles are rebuilt correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-sdkroot.py
+++ b/test/mac/gyptest-sdkroot.py
@@ -7,6 +7,7 @@
 """
 Verifies that setting SDKROOT works.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -16,7 +17,7 @@ import sys
 
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-sourceless-module.py
+++ b/test/mac/gyptest-sourceless-module.py
@@ -7,13 +7,14 @@
 """
 Verifies that bundles that have no 'sources' (pure resource containers) work.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/mac/gyptest-strip-default.py
+++ b/test/mac/gyptest-strip-default.py
@@ -7,6 +7,7 @@
 """
 Verifies that the default STRIP_STYLEs match between different generators.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -40,8 +41,8 @@ if sys.platform == 'darwin':
     o = re.sub(r'^[a-fA-F0-9]+', 'XXXXXXXX', o, flags=re.MULTILINE)
     assert not proc.returncode
     if o != o_expected:
-      print 'Stripping: Expected symbols """\n%s""", got """\n%s"""' % (
-          o_expected, o)
+      print('Stripping: Expected symbols """\n%s""", got """\n%s"""' % (
+          o_expected, o))
       test.fail_test()
 
   CheckNsyms(OutPath('libsingle_dylib.dylib'),

--- a/test/mac/gyptest-strip.py
+++ b/test/mac/gyptest-strip.py
@@ -7,6 +7,7 @@
 """
 Verifies that stripping works.
 """
+from __future__ import print_function
 
 import TestGyp
 import TestMac
@@ -16,7 +17,7 @@ import subprocess
 import sys
 import time
 
-print "This test is currently disabled: https://crbug.com/483696."
+print("This test is currently disabled: https://crbug.com/483696.")
 sys.exit(0)
 
 if sys.platform == 'darwin':
@@ -36,7 +37,7 @@ if sys.platform == 'darwin':
     m = r.search(o)
     n = int(m.group(1))
     if n != n_expected:
-      print 'Stripping: Expected %d symbols, got %d' % (n_expected, n)
+      print('Stripping: Expected %d symbols, got %d' % (n_expected, n))
       test.fail_test()
 
   # Starting with Xcode 5.0, clang adds an additional symbols to the compiled

--- a/test/mac/gyptest-swift-library.py
+++ b/test/mac/gyptest-swift-library.py
@@ -7,6 +7,7 @@
 """
 Verifies that a swift framework builds correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 import TestMac
@@ -16,7 +17,7 @@ import sys
 import subprocess
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['xcode'])
@@ -26,7 +27,7 @@ if sys.platform == 'darwin':
     output = subprocess.check_output(['nm', '-j', path])
     idx = output.find(symbol)
     if idx == -1:
-      print 'Swift: Could not find symobl: %s' % symbol
+      print('Swift: Could not find symobl: %s' % symbol)
       test.fail_test()
 
   test_cases = []

--- a/test/mac/gyptest-xcode-env-order.py
+++ b/test/mac/gyptest-xcode-env-order.py
@@ -7,6 +7,7 @@
 """
 Verifies that dependent Xcode settings are processed correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 import TestMac
@@ -15,7 +16,7 @@ import subprocess
 import sys
 
 if sys.platform == 'darwin':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['ninja', 'make', 'xcode'])

--- a/test/make_global_settings/basics/gyptest-make_global_settings.py
+++ b/test/make_global_settings/basics/gyptest-make_global_settings.py
@@ -7,12 +7,13 @@
 """
 Verifies make_global_settings.
 """
+from __future__ import print_function
 
 import os
 import sys
 import TestGyp
 
-print "This test is currently disabled: https://crbug.com/483696."
+print("This test is currently disabled: https://crbug.com/483696.")
 sys.exit(0)
 
 test_format = ['ninja']

--- a/test/make_global_settings/env-wrapper/gyptest-wrapper.py
+++ b/test/make_global_settings/env-wrapper/gyptest-wrapper.py
@@ -7,12 +7,13 @@
 """
 Verifies *_wrapper in environment.
 """
+from __future__ import print_function
 
 import os
 import sys
 import TestGyp
 
-print "This test is currently disabled: https://crbug.com/483696."
+print("This test is currently disabled: https://crbug.com/483696.")
 sys.exit(0)
 
 test_format = ['ninja']

--- a/test/make_global_settings/full-toolchain/gyptest-make_global_settings.py
+++ b/test/make_global_settings/full-toolchain/gyptest-make_global_settings.py
@@ -7,6 +7,7 @@
 """
 Verifies make_global_settings works with the full toolchain.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -17,7 +18,7 @@ if sys.platform == 'win32':
   # and make not supported on windows at all.
   sys.exit(0)
 
-print "This test is currently disabled: https://crbug.com/483696."
+print("This test is currently disabled: https://crbug.com/483696.")
 sys.exit(0)
 
 test = TestGyp.TestGyp(formats=['ninja'])

--- a/test/make_global_settings/full-toolchain/my_nm.py
+++ b/test/make_global_settings/full-toolchain/my_nm.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+from __future__ import print_function
 import sys
-print sys.argv
+print(sys.argv)
 with open('RAN_MY_NM', 'w') as f:
   f.write('RAN_MY_NM')

--- a/test/make_global_settings/full-toolchain/my_readelf.py
+++ b/test/make_global_settings/full-toolchain/my_readelf.py
@@ -2,7 +2,8 @@
 # Copyright (c) 2014 Google Inc. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
+from __future__ import print_function
 import sys
-print sys.argv
+print(sys.argv)
 with open('RAN_MY_READELF', 'w') as f:
   f.write('RAN_MY_READELF')

--- a/test/make_global_settings/wrapper/gyptest-wrapper.py
+++ b/test/make_global_settings/wrapper/gyptest-wrapper.py
@@ -7,12 +7,13 @@
 """
 Verifies *_wrapper in make_global_settings.
 """
+from __future__ import print_function
 
 import os
 import sys
 import TestGyp
 
-print "This test is currently disabled: https://crbug.com/483696."
+print("This test is currently disabled: https://crbug.com/483696.")
 sys.exit(0)
 
 test_format = ['ninja']

--- a/test/many-actions/gyptest-many-actions-unsorted.py
+++ b/test/many-actions/gyptest-many-actions-unsorted.py
@@ -8,11 +8,12 @@
 Make sure lots of actions in the same target don't cause exceeding command
 line length.
 """
+from __future__ import print_function
 
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 import TestGyp

--- a/test/many-actions/gyptest-many-actions.py
+++ b/test/many-actions/gyptest-many-actions.py
@@ -8,11 +8,12 @@
 Make sure lots of actions in the same target don't cause exceeding command
 line length.
 """
+from __future__ import print_function
 
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/msvs/config_attrs/gyptest-config_attrs.py
+++ b/test/msvs/config_attrs/gyptest-config_attrs.py
@@ -9,6 +9,7 @@ Verifies that msvs_configuration_attributes and
 msbuild_configuration_attributes are applied by using
 them to set the OutputDirectory.
 """
+from __future__ import print_function
 
 import TestGyp
 import os
@@ -16,7 +17,7 @@ import os
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/msvs/rules_stdout_stderr/rule_stdout.py
+++ b/test/msvs/rules_stdout_stderr/rule_stdout.py
@@ -3,4 +3,5 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-print "This will go to stdout"
+from __future__ import print_function
+print("This will go to stdout")

--- a/test/ninja/action_dependencies/gyptest-action-dependencies.py
+++ b/test/ninja/action_dependencies/gyptest-action-dependencies.py
@@ -8,12 +8,13 @@
 Verify that building an object file correctly depends on running actions in
 dependent targets, but not the targets themselves.
 """
+from __future__ import print_function
 
 import os
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/ninja/solibs_avoid_relinking/gyptest-solibs-avoid-relinking.py
+++ b/test/ninja/solibs_avoid_relinking/gyptest-solibs-avoid-relinking.py
@@ -8,6 +8,7 @@
 Verify that relinking a solib doesn't relink a dependent executable if the
 solib's public API hasn't changed.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -24,7 +25,7 @@ test = TestGyp.TestGyp(formats=['ninja'])
 
 if not os.environ.get('ProgramFiles(x86)'):
   # TODO(scottmg)
-  print 'Skipping test on x86, http://crbug.com/365833'
+  print('Skipping test on x86, http://crbug.com/365833')
   test.pass_test()
 
 test.run_gyp('solibs_avoid_relinking.gyp')

--- a/test/rules-dirname/gyptest-dirname.py
+++ b/test/rules-dirname/gyptest-dirname.py
@@ -7,13 +7,14 @@
 """
 Verifies simple rules when using an explicit build target of 'all'.
 """
+from __future__ import print_function
 
 import TestGyp
 import os
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/rules-variables/gyptest-rules-variables.py
+++ b/test/rules-variables/gyptest-rules-variables.py
@@ -7,11 +7,12 @@
 """
 Verifies rules related variables are expanded.
 """
+from __future__ import print_function
 
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/rules/gyptest-all.py
+++ b/test/rules/gyptest-all.py
@@ -7,11 +7,12 @@
 """
 Verifies simple rules when using an explicit build target of 'all'.
 """
+from __future__ import print_function
 
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/rules/gyptest-default.py
+++ b/test/rules/gyptest-default.py
@@ -7,11 +7,12 @@
 """
 Verifies simple rules when using an explicit build target of 'all'.
 """
+from __future__ import print_function
 
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 

--- a/test/standalone/gyptest-standalone.py
+++ b/test/standalone/gyptest-standalone.py
@@ -8,6 +8,7 @@
 Verifies that a project hierarchy created with the --generator-output=
 option can be built even when it's relocated to a different path.
 """
+from __future__ import print_function
 
 import TestGyp
 import os
@@ -26,7 +27,7 @@ for root, dirs, files in os.walk("."):
     file = os.path.join(root, file)
     contents = open(file).read()
     if 'standalone.gyp' in contents:
-      print 'gyp file referenced in generated output: %s' % file
+      print('gyp file referenced in generated output: %s' % file)
       test.fail_test()
 
 

--- a/test/variables/commands/gyptest-commands-ignore-env.py
+++ b/test/variables/commands/gyptest-commands-ignore-env.py
@@ -8,6 +8,7 @@
 Test that environment variables are ignored when --ignore-environment is
 specified.
 """
+from __future__ import print_function
 
 import os
 
@@ -39,7 +40,7 @@ test.run_gyp('commands.gyp',
 contents = test.read('commands.gypd').replace('\r', '')
 expect = test.read('commands.gypd.golden').replace('\r', '')
 if not test.match(contents, expect):
-  print "Unexpected contents of `commands.gypd'"
+  print("Unexpected contents of `commands.gypd'")
   test.diff(expect, contents, 'commands.gypd ')
   test.fail_test()
 

--- a/test/variables/commands/gyptest-commands-repeated.py
+++ b/test/variables/commands/gyptest-commands-repeated.py
@@ -8,6 +8,7 @@
 Test variable expansion of '<!()' syntax commands where they are evaluated
 more then once..
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -31,7 +32,7 @@ test.run_gyp('commands-repeated.gyp',
 contents = test.read('commands-repeated.gypd').replace('\r\n', '\n')
 expect = test.read('commands-repeated.gypd.golden').replace('\r\n', '\n')
 if not test.match(contents, expect):
-  print "Unexpected contents of `commands-repeated.gypd'"
+  print("Unexpected contents of `commands-repeated.gypd'")
   test.diff(expect, contents, 'commands-repeated.gypd ')
   test.fail_test()
 

--- a/test/variables/commands/gyptest-commands.py
+++ b/test/variables/commands/gyptest-commands.py
@@ -7,6 +7,7 @@
 """
 Test variable expansion of '<!()' syntax commands.
 """
+from __future__ import print_function
 
 import os
 
@@ -32,7 +33,7 @@ test.run_gyp('commands.gyp',
 contents = test.read('commands.gypd').replace('\r', '')
 expect = test.read('commands.gypd.golden').replace('\r', '')
 if not test.match(contents, expect):
-  print "Unexpected contents of `commands.gypd'"
+  print("Unexpected contents of `commands.gypd'")
   test.diff(expect, contents, 'commands.gypd ')
   test.fail_test()
 

--- a/test/variables/commands/repeated_multidir/print_cwd_basename.py
+++ b/test/variables/commands/repeated_multidir/print_cwd_basename.py
@@ -4,7 +4,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+from __future__ import print_function
 import os
 import os.path
 
-print os.path.basename(os.getcwd())
+print(os.path.basename(os.getcwd()))

--- a/test/variables/commands/test.py
+++ b/test/variables/commands/test.py
@@ -1,1 +1,2 @@
-print "sample\\path\\foo.cpp"
+from __future__ import print_function
+print("sample\\path\\foo.cpp")

--- a/test/variables/filelist/gyptest-filelist-golden.py
+++ b/test/variables/filelist/gyptest-filelist-golden.py
@@ -7,6 +7,7 @@
 """
 Test variable expansion of '<|(list.txt ...)' syntax commands.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -36,14 +37,14 @@ contents = test.read('src/filelist.gypd').replace(
     '\r', '').replace('\\\\', '/')
 expect = test.read('filelist.gypd.golden').replace('\r', '')
 if not test.match(contents, expect):
-  print "Unexpected contents of `src/filelist.gypd'"
+  print("Unexpected contents of `src/filelist.gypd'")
   test.diff(expect, contents, 'src/filelist.gypd ')
   test.fail_test()
 
 contents = test.read('src/names.txt')
 expect = 'John\nJacob\nJingleheimer\nSchmidt\n'
 if not test.match(contents, expect):
-  print "Unexpected contents of `src/names.txt'"
+  print("Unexpected contents of `src/names.txt'")
   test.diff(expect, contents, 'src/names.txt ')
   test.fail_test()
 

--- a/test/variables/filelist/gyptest-filelist.py
+++ b/test/variables/filelist/gyptest-filelist.py
@@ -7,6 +7,7 @@
 """
 Test variable expansion of '<|(list.txt ...)' syntax commands.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -22,7 +23,7 @@ test.build('filelist2.gyp', 'foo', chdir=CHDIR)
 contents = test.read('src/dummy_foo').replace('\r', '')
 expect = 'John\nJacob\nJingleheimer\nSchmidt\n'
 if not test.match(contents, expect):
-  print "Unexpected contents of `src/dummy_foo'"
+  print("Unexpected contents of `src/dummy_foo'")
   test.diff(expect, contents, 'src/dummy_foo')
   test.fail_test()
 

--- a/test/win/gyptest-cl-enable-enhanced-instruction-set.py
+++ b/test/win/gyptest-cl-enable-enhanced-instruction-set.py
@@ -7,6 +7,7 @@
 """
 Test VCCLCompilerTool EnableEnhancedInstructionSet setting.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -14,7 +15,7 @@ import os
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp()

--- a/test/win/gyptest-cl-function-level-linking.py
+++ b/test/win/gyptest-cl-function-level-linking.py
@@ -7,6 +7,7 @@
 """
 Make sure function-level linking setting is extracted properly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -22,10 +23,10 @@ if sys.platform == 'win32':
   def CheckForSectionString(binary, search_for, should_exist):
     output = test.run_dumpbin('/headers', binary)
     if should_exist and search_for not in output:
-      print 'Did not find "%s" in %s' % (search_for, binary)
+      print('Did not find "%s" in %s' % (search_for, binary))
       test.fail_test()
     elif not should_exist and search_for in output:
-      print 'Found "%s" in %s (and shouldn\'t have)' % (search_for, binary)
+      print('Found "%s" in %s (and shouldn\'t have)' % (search_for, binary))
       test.fail_test()
 
   def Object(proj, obj):

--- a/test/win/gyptest-command-quote.py
+++ b/test/win/gyptest-command-quote.py
@@ -11,13 +11,14 @@ application in the path. Specifically, this means not quoting something like
 "call x.bat", lest the shell look for a program named "call x.bat", rather
 than calling "x.bat".
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['msvs', 'ninja'])

--- a/test/win/gyptest-link-defrelink.py
+++ b/test/win/gyptest-link-defrelink.py
@@ -7,13 +7,14 @@
 """
 Make sure a relink is performed when a .def file is touched.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['msvs', 'ninja'])

--- a/test/win/gyptest-link-enable-uac.py
+++ b/test/win/gyptest-link-enable-uac.py
@@ -68,8 +68,8 @@ if sys.platform == 'win32':
   test.fail_test(len(execution_level) != 1)
   execution_level = execution_level[0].attributes
   test.fail_test(not (
-      execution_level.has_key('level') and
-      execution_level.has_key('uiAccess') and
+      'level' in execution_level and
+      'uiAccess' in execution_level and
       execution_level['level'].nodeValue == 'asInvoker' and
       execution_level['uiAccess'].nodeValue == 'false'))
 
@@ -87,8 +87,8 @@ if sys.platform == 'win32':
   test.fail_test(len(execution_level) != 1)
   execution_level = execution_level[0].attributes
   test.fail_test(not (
-      execution_level.has_key('level') and
-      execution_level.has_key('uiAccess') and
+      'level' in execution_level and
+      'uiAccess' in execution_level and
       execution_level['level'].nodeValue == 'requireAdministrator' and
       execution_level['uiAccess'].nodeValue == 'true'))
 

--- a/test/win/gyptest-link-enable-winrt-app-revision.py
+++ b/test/win/gyptest-link-enable-winrt-app-revision.py
@@ -7,6 +7,7 @@
 """
 Make sure msvs_application_type_revision works correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -16,7 +17,7 @@ import struct
 
 CHDIR = 'winrt-app-type-revision'
 
-print 'This test is not currently working on the bots: https://code.google.com/p/gyp/issues/detail?id=466'
+print('This test is not currently working on the bots: https://code.google.com/p/gyp/issues/detail?id=466')
 sys.exit(0)
 
 if (sys.platform == 'win32' and

--- a/test/win/gyptest-link-enable-winrt-target-platform-version.py
+++ b/test/win/gyptest-link-enable-winrt-target-platform-version.py
@@ -7,6 +7,7 @@
 """
 Make sure msvs_target_platform_version works correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -16,7 +17,7 @@ import struct
 
 CHDIR = 'winrt-target-platform-version'
 
-print 'This test is not currently working on the bots: https://code.google.com/p/gyp/issues/detail?id=466'
+print('This test is not currently working on the bots: https://code.google.com/p/gyp/issues/detail?id=466')
 sys.exit(0)
 
 if (sys.platform == 'win32' and

--- a/test/win/gyptest-link-enable-winrt.py
+++ b/test/win/gyptest-link-enable-winrt.py
@@ -7,6 +7,7 @@
 """
 Make sure msvs_enable_winrt works correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -16,7 +17,7 @@ import struct
 
 CHDIR = 'enable-winrt'
 
-print 'This test is not currently working on the bots: https://code.google.com/p/gyp/issues/detail?id=466'
+print('This test is not currently working on the bots: https://code.google.com/p/gyp/issues/detail?id=466')
 sys.exit(0)
 
 if (sys.platform == 'win32' and

--- a/test/win/gyptest-link-large-pdb.py
+++ b/test/win/gyptest-link-large-pdb.py
@@ -7,6 +7,7 @@
 """
 Make sure msvs_large_pdb works correctly.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -14,7 +15,7 @@ import struct
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
 
@@ -37,8 +38,8 @@ def CheckImageAndPdb(test, image_basename, expected_page_size,
   pdb_file.seek(32, 0)
   page_size = struct.unpack('<I', pdb_file.read(4))[0]
   if page_size != expected_page_size:
-    print "Expected page size of %d, got %d for PDB file `%s'." % (
-        expected_page_size, page_size, pdb_path)
+    print("Expected page size of %d, got %d for PDB file `%s'." % (
+        expected_page_size, page_size, pdb_path))
 
 
 if sys.platform == 'win32':

--- a/test/win/gyptest-link-ordering.py
+++ b/test/win/gyptest-link-ordering.py
@@ -7,6 +7,7 @@
 """
 Make sure the link order of object files is the same between msvs and ninja.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -48,7 +49,7 @@ _main:
 '''
 
   if expected_disasm_basic not in GetDisasm('test_ordering_exe.exe'):
-    print GetDisasm('test_ordering_exe.exe')
+    print(GetDisasm('test_ordering_exe.exe'))
     test.fail_test()
 
   # Similar to above. The VS generator handles subdirectories differently.
@@ -69,7 +70,7 @@ _main:
 '''
 
   if expected_disasm_subdirs not in GetDisasm('test_ordering_subdirs.exe'):
-    print GetDisasm('test_ordering_subdirs.exe')
+    print(GetDisasm('test_ordering_subdirs.exe'))
     test.fail_test()
 
   # Similar, but with directories mixed into folders (crt and main at the same
@@ -95,7 +96,7 @@ _main:
 
   if (expected_disasm_subdirs_mixed not in
       GetDisasm('test_ordering_subdirs_mixed.exe')):
-    print GetDisasm('test_ordering_subdirs_mixed.exe')
+    print(GetDisasm('test_ordering_subdirs_mixed.exe'))
     test.fail_test()
 
   test.pass_test()

--- a/test/win/gyptest-link-restat-importlib.py
+++ b/test/win/gyptest-link-restat-importlib.py
@@ -8,6 +8,7 @@
 Make sure we don't cause unnecessary builds due to import libs appearing
 to be out of date.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -20,7 +21,7 @@ if sys.platform == 'win32':
 
   if not os.environ.get('ProgramFiles(x86)'):
     # TODO(scottmg)
-    print 'Skipping test on x86, http://crbug.com/365833'
+    print('Skipping test on x86, http://crbug.com/365833')
     test.pass_test()
 
   CHDIR = 'importlib'

--- a/test/win/gyptest-macro-targetfilename.py
+++ b/test/win/gyptest-macro-targetfilename.py
@@ -7,6 +7,7 @@
 """
 Make sure macro expansion of $(TargetFileName) is handled.
 """
+from __future__ import print_function
 
 import TestGyp
 
@@ -14,7 +15,7 @@ import os
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['msvs', 'ninja'])

--- a/test/win/gyptest-rc-build.py
+++ b/test/win/gyptest-rc-build.py
@@ -7,13 +7,14 @@
 """
 Make sure we build and include .rc files.
 """
+from __future__ import print_function
 
 import TestGyp
 
 import sys
 
 if sys.platform == 'win32':
-  print "This test is currently disabled: https://crbug.com/483696."
+  print("This test is currently disabled: https://crbug.com/483696.")
   sys.exit(0)
 
   test = TestGyp.TestGyp(formats=['msvs', 'ninja'])

--- a/tools/graphviz.py
+++ b/tools/graphviz.py
@@ -7,6 +7,7 @@
 """Using the JSON dumped by the dump-dependency-json generator,
 generate input suitable for graphviz to render a dependency graph of
 targets."""
+from __future__ import print_function
 
 import collections
 import json
@@ -50,9 +51,9 @@ def WriteGraph(edges):
     build_file, target_name, toolset = ParseTarget(src)
     files[build_file].append(src)
 
-  print 'digraph D {'
-  print '  fontsize=8'  # Used by subgraphs.
-  print '  node [fontsize=8]'
+  print('digraph D {')
+  print('  fontsize=8')  # Used by subgraphs.
+  print('  node [fontsize=8]')
 
   # Output nodes by file.  We must first write out each node within
   # its file grouping before writing out any edges that may refer
@@ -63,31 +64,31 @@ def WriteGraph(edges):
       # the display by making it a box without an internal node.
       target = targets[0]
       build_file, target_name, toolset = ParseTarget(target)
-      print '  "%s" [shape=box, label="%s\\n%s"]' % (target, filename,
-                                                     target_name)
+      print('  "%s" [shape=box, label="%s\\n%s"]' % (target, filename,
+                                                     target_name))
     else:
       # Group multiple nodes together in a subgraph.
-      print '  subgraph "cluster_%s" {' % filename
-      print '    label = "%s"' % filename
+      print('  subgraph "cluster_%s" {' % filename)
+      print('    label = "%s"' % filename)
       for target in targets:
         build_file, target_name, toolset = ParseTarget(target)
-        print '    "%s" [label="%s"]' % (target, target_name)
-      print '  }'
+        print('    "%s" [label="%s"]' % (target, target_name))
+      print('  }')
 
   # Now that we've placed all the nodes within subgraphs, output all
   # the edges between nodes.
   for src, dsts in edges.items():
     for dst in dsts:
-      print '  "%s" -> "%s"' % (src, dst)
+      print('  "%s" -> "%s"' % (src, dst))
 
-  print '}'
+  print('}')
 
 
 def main():
   if len(sys.argv) < 2:
-    print >>sys.stderr, __doc__
-    print >>sys.stderr
-    print >>sys.stderr, 'usage: %s target1 target2...' % (sys.argv[0])
+    print(__doc__, file=sys.stderr)
+    print(file=sys.stderr)
+    print('usage: %s target1 target2...' % (sys.argv[0]), file=sys.stderr)
     return 1
 
   edges = LoadEdges('dump.json', sys.argv[1:])

--- a/tools/pretty_gyp.py
+++ b/tools/pretty_gyp.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 """Pretty-prints the contents of a GYP file."""
+from __future__ import print_function
 
 import sys
 import re
@@ -125,15 +126,15 @@ def prettyprint_input(lines):
         (brace_diff, after) = count_braces(line)
       if brace_diff != 0:
         if after:
-          print " " * (basic_offset * indent) + line
+          print(" " * (basic_offset * indent) + line)
           indent += brace_diff
         else:
           indent += brace_diff
-          print " " * (basic_offset * indent) + line
+          print(" " * (basic_offset * indent) + line)
       else:
-        print " " * (basic_offset * indent) + line
+        print(" " * (basic_offset * indent) + line)
     else:
-      print ""
+      print("")
     last_line = line
 
 

--- a/tools/pretty_sln.py
+++ b/tools/pretty_sln.py
@@ -11,6 +11,7 @@
 
    Then it outputs a possible build order.
 """
+from __future__ import print_function
 
 __author__ = 'nsylvain (Nicolas Sylvain)'
 
@@ -26,7 +27,7 @@ def BuildProject(project, built, projects, deps):
   for dep in deps[project]:
     if dep not in built:
       BuildProject(dep, built, projects, deps)
-  print project
+  print(project)
   built.append(project)
 
 def ParseSolution(solution_file):
@@ -100,44 +101,44 @@ def ParseSolution(solution_file):
   return (projects, dependencies)
 
 def PrintDependencies(projects, deps):
-  print "---------------------------------------"
-  print "Dependencies for all projects"
-  print "---------------------------------------"
-  print "--                                   --"
+  print("---------------------------------------")
+  print("Dependencies for all projects")
+  print("---------------------------------------")
+  print("--                                   --")
 
   for (project, dep_list) in sorted(deps.items()):
-    print "Project : %s" % project
-    print "Path : %s" % projects[project][0]
+    print("Project : %s" % project)
+    print("Path : %s" % projects[project][0])
     if dep_list:
       for dep in dep_list:
-        print "  - %s" % dep
-    print ""
+        print("  - %s" % dep)
+    print("")
 
-  print "--                                   --"
+  print("--                                   --")
 
 def PrintBuildOrder(projects, deps):
-  print "---------------------------------------"
-  print "Build order                            "
-  print "---------------------------------------"
-  print "--                                   --"
+  print("---------------------------------------")
+  print("Build order                            ")
+  print("---------------------------------------")
+  print("--                                   --")
 
   built = []
   for (project, _) in sorted(deps.items()):
     if project not in built:
       BuildProject(project, built, projects, deps)
 
-  print "--                                   --"
+  print("--                                   --")
 
 def PrintVCProj(projects):
 
   for project in projects:
-    print "-------------------------------------"
-    print "-------------------------------------"
-    print project
-    print project
-    print project
-    print "-------------------------------------"
-    print "-------------------------------------"
+    print("-------------------------------------")
+    print("-------------------------------------")
+    print(project)
+    print(project)
+    print(project)
+    print("-------------------------------------")
+    print("-------------------------------------")
 
     project_path = os.path.abspath(os.path.join(os.path.dirname(sys.argv[1]),
                                                 projects[project][2]))
@@ -153,7 +154,7 @@ def PrintVCProj(projects):
 def main():
   # check if we have exactly 1 parameter.
   if len(sys.argv) < 2:
-    print 'Usage: %s "c:\\path\\to\\project.sln"' % sys.argv[0]
+    print('Usage: %s "c:\\path\\to\\project.sln"' % sys.argv[0])
     return 1
 
   (projects, deps) = ParseSolution(sys.argv[1])

--- a/tools/pretty_vcproj.py
+++ b/tools/pretty_vcproj.py
@@ -11,6 +11,7 @@
 
    It outputs the resulting xml to stdout.
 """
+from __future__ import print_function
 
 __author__ = 'nsylvain (Nicolas Sylvain)'
 
@@ -61,7 +62,7 @@ class CmpNode(object):
 def PrettyPrintNode(node, indent=0):
   if node.nodeType == Node.TEXT_NODE:
     if node.data.strip():
-      print '%s%s' % (' '*indent, node.data.strip())
+      print('%s%s' % (' '*indent, node.data.strip()))
     return
 
   if node.childNodes:
@@ -73,23 +74,23 @@ def PrettyPrintNode(node, indent=0):
 
   # Print the main tag
   if attr_count == 0:
-    print '%s<%s>' % (' '*indent, node.nodeName)
+    print('%s<%s>' % (' '*indent, node.nodeName))
   else:
-    print '%s<%s' % (' '*indent, node.nodeName)
+    print('%s<%s' % (' '*indent, node.nodeName))
 
     all_attributes = []
     for (name, value) in node.attributes.items():
       all_attributes.append((name, value))
       all_attributes.sort(CmpTuple())
     for (name, value) in all_attributes:
-      print '%s  %s="%s"' % (' '*indent, name, value)
-    print '%s>' % (' '*indent)
+      print('%s  %s="%s"' % (' '*indent, name, value))
+    print('%s>' % (' '*indent))
   if node.nodeValue:
-    print '%s  %s' % (' '*indent, node.nodeValue)
+    print('%s  %s' % (' '*indent, node.nodeValue))
 
   for sub_node in node.childNodes:
     PrettyPrintNode(sub_node, indent=indent+2)
-  print '%s</%s>' % (' '*indent, node.nodeName)
+  print('%s</%s>' % (' '*indent, node.nodeName))
 
 
 def FlattenFilter(node):


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * __print()__ is a function in Python 3.
* Old style exceptions --> new style for Python 3
    * Python 3 treats old style exceptions as syntax errors but new style exceptions work as expected in both Python 2 and Python 3.