### PR TITLE
travis.yml: Add Python testing in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 language: cpp
 compiler:
  - clang
-before_install: ./buildbot/travis-checkout.sh
-script: ./buildbot/travis-test.sh
 matrix:
-  allow_failures:
-    - python: 2.7
-    - python: 3.7
   include:
+    - before_install: ./buildbot/travis-checkout.sh
+      script: ./buildbot/travis-test.sh
     - python: 2.7
       language: python
-      before_install: pip install flake8
+      install: pip install flake8
       script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     - python: 3.7
       language: python
       dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-      before_install: pip install flake8
+      install: pip install flake8
       script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  allow_failures:
+    - python: 3.7
 os:
   - linux
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,20 @@ compiler:
  - clang
 before_install: ./buildbot/travis-checkout.sh
 script: ./buildbot/travis-test.sh
+matrix:
+  allow_failures:
+    - python: 2.7
+    - python: 3.7
+  include:
+    - python: 2.7
+      language: python
+      before_install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    - python: 3.7
+      language: python
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      before_install: pip install flake8
+      script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 os:
   - linux
 branches:


### PR DESCRIPTION
Three Travis CI test runs in parallel.  We remove __allow_failures__ as soon as the Python 3 tests pass.