### PR TITLE
Upgrade from buffer to memoryview for python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 Generate You Projects
 ===================================
 
-Documentation is available at [http://gyp3.org/](http://gyp3.org/) (or at the `md-pages` branch).
+Documentation is available at [http://gyp3.org/](http://gyp3.org/) (or at the [`gh-pages`](https://github.com/refack/GYP/blob/gh-pages/index.md) branch).

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 Generate You Projects
 ===================================
 
-Documentation is available at [http://gyp3.org/](http://gyp3.org/) (or at the [`gh-pages`](https://github.com/refack/GYP/blob/gh-pages/index.md) branch).
+Documentation is available at [https://refack.github.io/GYP/](https://refack.github.io/GYP/) (or at the `md-pages` branch).

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 Generate You Projects
 ===================================
 
-Documentation is available at [https://refack.github.io/GYP/](https://refack.github.io/GYP/) (or at the `md-pages` branch).
+Documentation is available at [http://gyp3.org/](http://gyp3.org/) (or at the `md-pages` branch).

--- a/test/lib/TestCmd.py
+++ b/test/lib/TestCmd.py
@@ -827,8 +827,7 @@ def send_all(p, data):
         sent = p.send(data)
         if sent is None:
             raise Exception(disconnect_message)
-        data = buffer(data, sent)
-
+        data = memoryview(data, sent)
 
 
 try:


### PR DESCRIPTION
__buffer__ was removed in Python 3 in favor of __memoryview__ which exists in Python 2.7 and Python 3.
* https://docs.python.org/3/library/stdtypes.html#memory-views
* https://docs.python.org/2/c-api/buffer.html