### PR TITLE
msvs: Support ARM64 configuration platform

### DIFF
--- a/gyp/MSVS/MSVSSettings.py
+++ b/gyp/MSVS/MSVSSettings.py
@@ -979,7 +979,9 @@ _Same(_midl, 'TargetEnvironment',
       _Enumeration(['NotSet',
                     'Win32',  # /env win32
                     'Itanium',  # /env ia64
-                    'X64']))  # /env x64
+                    'X64',  # /env x64
+                    'ARM64',  # /env arm64
+                  ]))
 _Same(_midl, 'EnableErrorChecks',
       _Enumeration(['EnableCustom',
                     'None',  # /error none

--- a/gyp/MSVS/MSVSVersion.py
+++ b/gyp/MSVS/MSVSVersion.py
@@ -6,7 +6,6 @@
 
 import os
 import glob
-from typing import Dict
 from gyp.MSVS.MSVSUtil import TryQueryRegistryValue
 
 msvs_version_map = {
@@ -130,7 +129,7 @@ class VisualStudioVersion(object):
     return script_data
 
 
-MSVS_VERSIONS = { # type: Dict[str, VisualStudioVersion]
+MSVS_VERSIONS = {
   '2019':
     VisualStudioVersion(
       short_name='2019',

--- a/gyp/generator/msvs.py
+++ b/gyp/generator/msvs.py
@@ -1825,6 +1825,8 @@ def _InitNinjaFlavor(params, target_list, target_dicts):
       configuration = '$(Configuration)'
       if params.get('target_arch') == 'x64':
         configuration += '_x64'
+      if params.get('target_arch') == 'arm64':
+        configuration += '_arm64'
       spec['msvs_external_builder_out_dir'] = os.path.join(
           gyp.common.RelativePath(params['options'].toplevel_dir, gyp_dir),
           ninja_generator.ComputeOutputDir(params),

--- a/gyp/generator/msvs.py
+++ b/gyp/generator/msvs.py
@@ -2565,7 +2565,7 @@ def _GenerateMSBuildRuleXmlFile(xml_path, msbuild_rules):
 
 def _GetConfigurationAndPlatform(name, settings):
   configuration = name.rsplit('_', 1)[0]
-  platform = settings.get('msvs_configuration_platform', 'Win32')
+  platform = settings.get('msvs_configuration_platform', 'x64')
   return configuration, platform
 
 

--- a/gyp/msvs_emulation.py
+++ b/gyp/msvs_emulation.py
@@ -200,7 +200,11 @@ class MsvsSettings(object):
   def GetVSMacroEnv(self, base_to_build=None, config=None):
     """Get a dict of variables mapping internal VS macro names to their gyp
     equivalents."""
-    target_platform = 'Win32' if self.GetArch(config) == 'x86' else 'x64'
+    target_arch = self.GetArch(config)
+    if target_arch == 'x86':
+      target_platform = 'Win32'
+    else:
+      target_platform = target_arch
     target_name = self.spec.get('product_prefix', '') + self.spec.get('product_name', self.spec['target_name'])
     target_dir = base_to_build + '\\' if base_to_build else ''
     target_ext = '.' + self.GetExtension()
@@ -276,7 +280,7 @@ class MsvsSettings(object):
     if not platform:  # If no specific override, use the configuration's.
       platform = configuration_platform
     # Map from platform to architecture.
-    return {'Win32': 'x86', 'x64': 'x64'}.get(platform, 'x86')
+    return {'Win32': 'x86', 'x64': 'x64', 'ARM64': 'arm64'}.get(platform, 'x86')
 
   def _TargetConfig(self, config):
     """Returns the target-specific configuration."""
@@ -475,7 +479,10 @@ class MsvsSettings(object):
     lib = self._GetWrapper(self, self.msvs_settings[config], 'VCLibrarianTool', append=libflags)
     libflags.extend(self._GetAdditionalLibraryDirectories('VCLibrarianTool', config, gyp_to_build_path))
     lib('LinkTimeCodeGeneration', map={'true': '/LTCG'})
-    lib('TargetMachine', map={'1': 'X86', '17': 'X64', '3': 'ARM'}, prefix='/MACHINE:')
+    # TODO: These 'map' values come from machineTypeOption enum,
+    # and does not have an official value for ARM64 in VS2017 (yet).
+    # It needs to verify the ARM64 value when machineTypeOption is updated.
+    lib('TargetMachine', map={'1': 'X86', '17': 'X64', '3': 'ARM', '18': 'ARM64'}, prefix='/MACHINE:')
     lib('AdditionalOptions')
     return libflags
 
@@ -514,7 +521,10 @@ class MsvsSettings(object):
     ld = self._GetWrapper(self, self.msvs_settings[config], 'VCLinkerTool', append=ldflags)
     self._GetDefFileAsLdflags(ldflags, gyp_to_build_path)
     ld('GenerateDebugInformation', map={'true': '/DEBUG'})
-    ld('TargetMachine', map={'1': 'X86', '17': 'X64', '3': 'ARM'}, prefix='/MACHINE:')
+    # TODO: These 'map' values come from machineTypeOption enum,
+    # and does not have an official value for ARM64 in VS2017 (yet).
+    # It needs to verify the ARM64 value when machineTypeOption is updated.
+    ld('TargetMachine', map={'1': 'X86', '17': 'X64', '3': 'ARM', '18': 'ARM64'}, prefix='/MACHINE:')
     ldflags.extend(self._GetAdditionalLibraryDirectories('VCLinkerTool', config, gyp_to_build_path))
     ld('DelayLoadDLLs', prefix='/DELAYLOAD:')
     ld('TreatLinkerWarningAsErrors', prefix='/WX', map={'true': '', 'false': ':NO'})
@@ -764,7 +774,9 @@ class MsvsSettings(object):
     output = [header, dlldata, iid, proxy]
     variables = [('tlb', tlb), ('h', header), ('dlldata', dlldata), ('iid', iid), ('proxy', proxy)]
     # TODO(scottmg): Are there configuration settings to set these flags?
-    target_platform = 'win32' if self.GetArch(config) == 'x86' else 'x64'
+    target_platform = self.GetArch(config)
+    if target_platform == 'x86':
+      target_platform = 'win32'
     flags = ['/char', 'signed', '/env', target_platform, '/Oicf']
     return outdir, output, variables, flags
 

--- a/test/configurations/arm64/configurations.c
+++ b/test/configurations/arm64/configurations.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+  printf("Hello ARM64\n");
+  return 0;
+}

--- a/test/configurations/arm64/configurations.gyp
+++ b/test/configurations/arm64/configurations.gyp
@@ -1,0 +1,22 @@
+# Copyright (c) 2009 Google Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+{
+  'target_defaults': {
+    'configurations': {
+      'Debug': {
+        'msvs_configuration_platform': 'ARM64',
+      },
+    },
+  },
+  'targets': [
+    {
+      'target_name': 'configurationsARM64',
+      'type': 'executable',
+      'sources': [
+        'configurations.c',
+      ],
+    },
+  ],
+}

--- a/test/configurations/arm64/gyptest-arm64.py
+++ b/test/configurations/arm64/gyptest-arm64.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2012 Google Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""
+Verifies build of an executable for ARM64 configurations.
+"""
+
+import TestGyp
+
+import sys
+
+formats = ['msvs']
+if sys.platform == 'win32':
+  formats += ['ninja']
+test = TestGyp.TestGyp(formats=formats)
+
+test.run_gyp('configurations.gyp')
+test.set_configuration('Debug|ARM64')
+test.build('configurations.gyp', test.ALL)
+
+output = test.run_dumpbin('/headers', test.built_file_path('configurations%s.exe' % 'ARM64'))
+if 'AA64 machine (ARM64)' not in output:
+  test.fail_test()
+test.pass_test()

--- a/test/win/gyptest-midl-rules.py
+++ b/test/win/gyptest-midl-rules.py
@@ -17,7 +17,7 @@ if sys.platform == 'win32':
 
   CHDIR = 'idl-rules'
   test.run_gyp('basic-idl.gyp', chdir=CHDIR)
-  for platform in ['Win32', 'x64']:
+  for platform in ['Win32', 'x64', 'ARM64']:
     test.set_configuration('Debug|%s' % platform)
     test.build('basic-idl.gyp', test.ALL, chdir=CHDIR)
 
@@ -25,4 +25,4 @@ if sys.platform == 'win32':
     if test.format == 'ninja' and 'Processing' in test.stdout():
       test.fail_test()
 
-    test.pass_test()
+  test.pass_test()

--- a/test/win/idl-rules/basic-idl.gyp
+++ b/test/win/idl-rules/basic-idl.gyp
@@ -15,6 +15,10 @@
         'inherit_from': ['Debug'],
         'msvs_configuration_platform': 'x64',
       },
+      'Debug_ARM64': {
+        'inherit_from': ['Debug'],
+        'msvs_configuration_platform': 'ARM64',
+      },
     },
   },
   'targets': [


### PR DESCRIPTION
* This change is intent to support top-level ARM64 configuration, so a
project can be built as ARM64 project.
* Unit test also included