### PR TITLE
Travis CI: Setup with Python 3.7, not 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ osx-setup-steps: &osx-setup-steps
   language: cpp  # 'language: python' is not yet supported on macOS
   # before_install: brew upgrade python  # takes too long
   install:
+    - xcode-select --install
     - HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
     - pip3 install --upgrade pip pipenv
     - pipenv install --dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,12 @@ windows-setup-steps: &windows-setup-steps
 
 osx-setup-steps: &osx-setup-steps
   os: osx
+  osx_image: xcode10.2  # provides Python 3.7.2
   language: cpp  # 'language: python' is not yet supported on macOS
   # before_install: brew upgrade python  # takes too long
   install:
     - HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
-    - pip install --upgrade pip pipenv
+    - pip3 install --upgrade pip pipenv
     - pipenv install --dev
     - pipenv install PyObjC  # This is not in the Pipfile because it breaks other platforms https://github.com/pypa/pipenv/issues/3187
 
@@ -32,30 +33,27 @@ matrix:
     - name: "Linux: test with make and ninja on Python 3.7"
       python: '3.7'
       <<: *linux-setup-steps
-      script: pipenv run -v test -f make,ninja
 
     - name: "Linux: test with make and ninja on Python 2.7"
       python: '2.7'
       <<: *linux-setup-steps
-      script: pipenv run -v test -f make,ninja
 
     - name: "Windows: test with mocks on Python 3"
       <<: *windows-setup-steps
       env:
-        - PATH=/c/Python37:$PATH
+        - PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install: choco install python3
-      script: python -m pipenv run -v test -f make-mock,msvs-mock
+      script: pipenv run -v test -f make-mock,msvs-mock
 
     - name: "Windows: test with mocks on Python 2"
       <<: *windows-setup-steps
       env:
-        - PATH=/c/Python27:$PATH
+        - PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install: choco install python2
-      script: python -m pipenv run -v test -f make-mock,msvs-mock
+      script: pipenv run -v test -f make-mock,msvs-mock
 
     - name: "macOS: test with make and ninja on Python 3.7"
       <<: *osx-setup-steps
-      script: pipenv run -v test -f make,ninja
 
     - name: "lint with Python 2.7"
       python: '2.7'
@@ -67,5 +65,6 @@ matrix:
       <<: *linux-setup-steps
       script: pipenv run -v lint
 
+script: pipenv run -v test -f make,ninja
 notifications:
   slack: node4good:C2EI9vo04FY8Ce5u7kcOLlDw

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ osx-setup-steps: &osx-setup-steps
   language: cpp  # 'language: python' is not yet supported on macOS
   # before_install: brew upgrade python  # takes too long
   install:
-    - rm -rf /Library/Developer/CommandLineTools
+    - sudo rm -rf /Library/Developer/CommandLineTools
     - xcode-select --install
     - HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
     - pip3 install --upgrade pip pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ osx-setup-steps: &osx-setup-steps
   language: cpp  # 'language: python' is not yet supported on macOS
   # before_install: brew upgrade python  # takes too long
   install:
+    - rm -rf /Library/Developer/CommandLineTools
     - xcode-select --install
     - HOMEBREW_NO_AUTO_UPDATE=1 brew install ninja
     - pip3 install --upgrade pip pipenv

--- a/gyp/xcode_emulation.py
+++ b/gyp/xcode_emulation.py
@@ -1405,7 +1405,7 @@ def XcodeVersion():
     if version:
       version = re.search(r'^(\d{1,2}\.\d(\.\d+)?)', version).groups()[0]
     else:
-      raise GypError("No Xcode or CLT version detected!")
+      raise GypError("No Xcode or CLT version detected!  {}".format(version))
     # The CLT has no build information, so we return an empty string.
     version_list = [version, '']
   version = version_list[0]


### PR DESCRIPTION
On Python 3.7 __CLTVersion()__ is returning __None__.