### PR TITLE
src: fix some bugs and regressions

### DIFF
--- a/gyp/generator/make.py
+++ b/gyp/generator/make.py
@@ -354,10 +354,10 @@ def GenerateOutput(target_list, target_dicts, data, params):
     'AR.target': GetEnvironFallback(('AR_target', 'AR'), '$(AR)'),
     'CXX.target': GetEnvironFallback(('CXX_target', 'CXX'), '$(CXX)'),
     'LINK.target': GetEnvironFallback(('LINK_target', 'LINK'), '$(LINK)'),
-    'CC.host': GetEnvironFallback(('CC_host',), 'gcc'),
-    'AR.host': GetEnvironFallback(('AR_host',), 'ar'),
-    'CXX.host': GetEnvironFallback(('CXX_host',), 'g++'),
-    'LINK.host': GetEnvironFallback(('LINK_host',), '$(CXX.host)'),
+    'CC.host':     GetEnvironFallback(('CC_host',), 'cc'),
+    'AR.host':     GetEnvironFallback(('AR_host',), 'ar'),
+    'CXX.host':    GetEnvironFallback(('CXX_host',), 'c++'),
+    'LINK.host':   GetEnvironFallback(('LINK_host',), '$(CXX.host)'),
   })
 
   build_file, _, _ = gyp.common.ParseQualifiedTarget(target_list[0])

--- a/gyp/generator/msvs.py
+++ b/gyp/generator/msvs.py
@@ -1383,7 +1383,9 @@ def _GetMSVSAttributes(config, config_type):
 
 
 def _AddNormalizedSources(sources_set, sources_array):
-  sources_set.update(_NormalizedSource(s) for s in sources_array)
+  sources_list = [_NormalizedSource(s) for s in sources_array]
+  sources_list = sorted(sources_list, key=lambda s: os.path.basename(s))
+  sources_set.update(sources_list)
 
 
 def _PrepareListOfSources(spec, generator_flags, gyp_file):
@@ -2072,7 +2074,7 @@ def _MapFileToMsBuildSourceType(source, rule_dependencies, extension_to_rule_nam
   elif ext == '.rc':
     group = 'resource'
     element = 'ResourceCompile'
-  elif ext == '.asm':
+  elif ext in ('.asm', '.s', '.S'):
     group = 'masm'
     element = 'MASM'
     for platform in platforms:
@@ -2565,7 +2567,7 @@ def _GenerateMSBuildRuleXmlFile(xml_path, msbuild_rules):
 
 def _GetConfigurationAndPlatform(name, settings):
   configuration = name.rsplit('_', 1)[0]
-  platform = settings.get('msvs_configuration_platform', 'x64')
+  platform = settings.get('msvs_configuration_platform', 'Win32')
   return configuration, platform
 
 

--- a/test/compiler-override/gyptest-compiler-env-simple.py
+++ b/test/compiler-override/gyptest-compiler-env-simple.py
@@ -1,0 +1,24 @@
+"""
+Verifies that the user can override the compiler using CC/CXX environment variables.
+"""
+
+import TestGyp
+
+test = TestGyp.TestGyp(formats=['ninja', 'make'], platforms=['!win32'])
+
+expected = ['"ccache cc"']
+
+# Check that CC, CXX and LD set target compiler
+with TestGyp.LocalEnv({
+  'CC': expected[0],
+}):
+  test.run_gyp('compiler-exe.gyp')
+  if test.format == 'make':
+    expected_status = 2
+  else:
+    expected_status = 1
+  test.build('compiler-exe.gyp', verbose=True, status=expected_status, match=lambda a, b: True)
+  test.must_contain_all_lines(test.stdout(), expected)
+
+
+test.pass_test()

--- a/test/compiler-override/gyptest-compiler-env.py
+++ b/test/compiler-override/gyptest-compiler-env.py
@@ -9,23 +9,9 @@ environment variables.
 
 import TestGyp
 import os
-import copy
-import sys
-
-here = os.path.dirname(os.path.abspath(__file__))
-
-if sys.platform == 'win32':
-  # cross compiling not supported by ninja on windows
-  # and make not supported on windows at all.
-  sys.exit(0)
-
-# Clear any existing compiler related env vars.
-for key in ['CC', 'CXX', 'LINK', 'CC_host', 'CXX_host', 'LINK_host']:
-  if key in os.environ:
-    del os.environ[key]
 
 
-def CheckCompiler(test, gypfile, check_for, run_gyp):
+def CheckCompiler(gypfile, check_for, run_gyp):
   if run_gyp:
     test.run_gyp(gypfile)
   test.build(gypfile)
@@ -33,10 +19,8 @@ def CheckCompiler(test, gypfile, check_for, run_gyp):
   test.must_contain_all_lines(test.stdout(), check_for)
 
 
-test = TestGyp.TestGyp(formats=['ninja', 'make'])
-
 def TestTargetOveride():
-  expected = ['my_cc.py', 'my_cxx.py', 'FOO' ]
+  expected = ['my_cc.py', 'my_cxx.py', 'FOO']
 
   # ninja just uses $CC / $CXX as linker.
   if test.format not in ['ninja', 'xcode-ninja']:
@@ -49,7 +33,7 @@ def TestTargetOveride():
     os.environ['CXX'] = 'python %s/my_cxx.py FOO' % here
     os.environ['LINK'] = 'python %s/my_ld.py FOO_LINK' % here
 
-    CheckCompiler(test, 'compiler-exe.gyp', expected, True)
+    CheckCompiler('compiler-exe.gyp', expected, True)
   finally:
     os.environ.clear()
     os.environ.update(oldenv)
@@ -57,7 +41,7 @@ def TestTargetOveride():
   # Run the same tests once the eviron has been restored.  The
   # generated should have embedded all the settings in the
   # project files so the results should be the same.
-  CheckCompiler(test, 'compiler-exe.gyp', expected, False)
+  CheckCompiler('compiler-exe.gyp', expected, False)
 
 
 def TestTargetOverideCompilerOnly():
@@ -67,9 +51,7 @@ def TestTargetOverideCompilerOnly():
     os.environ['CC'] = 'python %s/my_cc.py FOO' % here
     os.environ['CXX'] = 'python %s/my_cxx.py FOO' % here
 
-    CheckCompiler(test, 'compiler-exe.gyp',
-                  ['my_cc.py', 'my_cxx.py', 'FOO'],
-                  True)
+    CheckCompiler('compiler-exe.gyp', ['my_cc.py', 'my_cxx.py', 'FOO'], True)
   finally:
     os.environ.clear()
     os.environ.update(oldenv)
@@ -77,13 +59,11 @@ def TestTargetOverideCompilerOnly():
   # Run the same tests once the eviron has been restored.  The
   # generated should have embedded all the settings in the
   # project files so the results should be the same.
-  CheckCompiler(test, 'compiler-exe.gyp',
-                ['my_cc.py', 'my_cxx.py', 'FOO'],
-                False)
+  CheckCompiler('compiler-exe.gyp', ['my_cc.py', 'my_cxx.py', 'FOO'], False)
 
 
 def TestHostOveride():
-  expected = ['my_cc.py', 'my_cxx.py', 'HOST' ]
+  expected = ['my_cc.py', 'my_cxx.py', 'HOST']
   if test.format != 'ninja':  # ninja just uses $CC / $CXX as linker.
     expected.append('HOST_LINK')
 
@@ -93,7 +73,7 @@ def TestHostOveride():
     os.environ['CC_host'] = 'python %s/my_cc.py HOST' % here
     os.environ['CXX_host'] = 'python %s/my_cxx.py HOST' % here
     os.environ['LINK_host'] = 'python %s/my_ld.py HOST_LINK' % here
-    CheckCompiler(test, 'compiler-host.gyp', expected, True)
+    CheckCompiler('compiler-host.gyp', expected, True)
   finally:
     os.environ.clear()
     os.environ.update(oldenv)
@@ -101,10 +81,22 @@ def TestHostOveride():
   # Run the same tests once the eviron has been restored.  The
   # generated should have embedded all the settings in the
   # project files so the results should be the same.
-  CheckCompiler(test, 'compiler-host.gyp', expected, False)
+  CheckCompiler('compiler-host.gyp', expected, False)
 
+
+# ======== Test script ========
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+# Clear any existing compiler related env vars.
+for key in ['CC', 'CXX', 'LINK', 'CC_host', 'CXX_host', 'LINK_host']:
+  if key in os.environ:
+    del os.environ[key]
+
+test = TestGyp.TestGyp(formats=['ninja', 'make'], platforms=['!win32'])
 
 TestTargetOveride()
 TestTargetOverideCompilerOnly()
+TestHostOveride()
 
 test.pass_test()

--- a/test/make_global_settings/ar/gyptest-make_global_settings_ar.py
+++ b/test/make_global_settings/ar/gyptest-make_global_settings_ar.py
@@ -12,23 +12,23 @@ import os
 import sys
 import TestGyp
 
-def verify_ar(tst, ars=None, rel_path=False, is_cross=True):
+def verify_ar(ars=None, rel_path=False, is_cross=True):
   ars = ars or {}
   rel_path = rel_path or set()
   for toolset in ['host', 'target']:
     ar = ars.get(toolset)
-    ar_expected = fix_ar(ar, toolset in rel_path, tst)
+    ar_expected = fix_ar(ar, toolset in rel_path)
     ar_suffix = '' if toolset == 'target' else 'host'
     if toolset == 'host':
       ar_expected = ar_expected or ('lib.exe' if sys.platform == 'win32' else 'ar')
-    if tst.is_make:
+    if test.is_make:
       ar_suffix = ar_suffix and '.' + ar_suffix
       filename = 'Makefile'
       if toolset == 'target' and ar is None:
-        tst.must_not_contain(filename, 'AR ?= ')
+        test.must_not_contain(filename, 'AR ?= ')
         return
       ar_rule = 'AR%s ?= %s' % (ar_suffix, ar_expected)
-    elif tst.is_ninja:
+    elif test.is_ninja:
       if not is_cross and toolset == 'host':
         return
       filename = 'out/Default/build.ninja'
@@ -36,22 +36,22 @@ def verify_ar(tst, ars=None, rel_path=False, is_cross=True):
       ar_expected = ar_expected or ('lib.exe' if sys.platform == 'win32' else 'ar')
       ar_rule = 'ar%s = %s' % (ar_suffix, ar_expected)
     else:
-      tst.fail_test()
+      test.fail_test()
       return
 
-    tst.must_contain(filename, ar_rule)
+    test.must_contain(filename, ar_rule)
 
 
-def fix_ar(ar, rel_path, tst):
+def fix_ar(ar, rel_path):
   if rel_path:
     if ar is None:
       ar_expected = ''
-    elif tst.is_make:
+    elif test.is_make:
       ar_expected = '$(abspath %s)' % ar
-    elif tst.is_ninja:
+    elif test.is_ninja:
       ar_expected = os.path.join('..', '..', ar)
     else:
-      tst.fail_test()
+      test.fail_test()
       return
   else:
     ar_expected = ar or ''
@@ -66,25 +66,25 @@ test = TestGyp.TestGyp(formats=test_format)
 
 # Check default values
 test.run_gyp('make_global_settings_ar.gyp')
-verify_ar(test, is_cross=False)
+verify_ar(is_cross=False)
 
 
 # Check default values with GYP_CROSSCOMPILE enabled.
 with TestGyp.LocalEnv({'GYP_CROSSCOMPILE': '1'}):
   test.run_gyp('make_global_settings_ar.gyp')
-verify_ar(test)
+verify_ar()
 
 
 # Test 'AR' in 'make_global_settings'.
 with TestGyp.LocalEnv({'GYP_CROSSCOMPILE': '1'}):
   test.run_gyp('make_global_settings_ar.gyp', '-Dcustom_ar_target=my_ar')
-verify_ar(test, ars={'target': 'my_ar'}, rel_path={'target', 'host'})
+verify_ar(ars={'target': 'my_ar'}, rel_path={'target', 'host'})
 
 
 # Test 'AR'/'AR.host' in 'make_global_settings'.
 with TestGyp.LocalEnv({'GYP_CROSSCOMPILE': '1'}):
   test.run_gyp('make_global_settings_ar.gyp', '-Dcustom_ar_target=my_ar_target1', '-Dcustom_ar_host=my_ar_host1')
-verify_ar(test, ars={'target': 'my_ar_target1', 'host': 'my_ar_host1'}, rel_path={'target', 'host'})
+verify_ar(ars={'target': 'my_ar_target1', 'host': 'my_ar_host1'}, rel_path={'target', 'host'})
 
 
 # Test $AR and $AR_host environment variables.
@@ -94,13 +94,13 @@ with TestGyp.LocalEnv({'AR': 'my_ar_target2', 'AR_host': 'my_ar_host2'}):
 ar_target_expected = None
 if test.is_ninja:
   ar_target_expected = 'lib.exe' if sys.platform == 'win32' else 'my_ar_target2'
-verify_ar(test, ars={'target': ar_target_expected, 'host': 'my_ar_host2'})
+verify_ar(ars={'target': ar_target_expected, 'host': 'my_ar_host2'})
 
 
 # Test 'AR' in 'make_global_settings' with $AR_host environment variable.
 with TestGyp.LocalEnv({'AR_host': 'my_ar_host3'}):
   test.run_gyp('make_global_settings_ar.gyp', '-Dcustom_ar_target=my_ar_target3')
-verify_ar(test, ars={'target': 'my_ar_target3', 'host': 'my_ar_host3'}, rel_path={'target'})
+verify_ar(ars={'target': 'my_ar_target3', 'host': 'my_ar_host3'}, rel_path={'target'})
 
 
 test.pass_test()

--- a/test/msvs/filters/gyptest-filters-2010.py
+++ b/test/msvs/filters/gyptest-filters-2010.py
@@ -42,14 +42,14 @@ required2 = '''\
     <ClCompile Include="..\\folder1\\nested\\a.c">
       <Filter>folder1\\nested</Filter>
     </ClCompile>
-    <ClCompile Include="..\\folder2\\d.c">
-      <Filter>folder2</Filter>
-    </ClCompile>
     <ClCompile Include="..\\folder1\\nested\\b.c">
       <Filter>folder1\\nested</Filter>
     </ClCompile>
     <ClCompile Include="..\\folder1\\other\\c.c">
       <Filter>folder1\\other</Filter>
+    </ClCompile>
+    <ClCompile Include="..\\folder2\\d.c">
+      <Filter>folder2</Filter>
     </ClCompile>
   </ItemGroup>
 '''.splitlines()

--- a/testlib/TestGyp.py
+++ b/testlib/TestGyp.py
@@ -626,12 +626,14 @@ class TestGypMake(TestGypBase):
   format = 'make'
   build_tool_list = ['make']
   ALL = 'all'
-  def build(self, gyp_file, target=None, **kw):
+  def build(self, gyp_file, target=None, verbose=False, **kw):
     """
     Runs a Make build using the Makefiles generated from the specified
     gyp_file.
     """
     arguments = kw.get('arguments', [])[:]
+    if verbose:
+      arguments.insert(0, 'V=1')
     if self.configuration:
       arguments.append('BUILDTYPE=' + self.configuration)
     if target not in (None, self.DEFAULT):
@@ -913,8 +915,10 @@ class TestGypNinja(TestGypOnMSToolchain):
     """
     TestGypBase.run_gyp(self, gyp_file, *args, **kw)
 
-  def build(self, gyp_file, target=None, **kw):
+  def build(self, gyp_file, target=None, verbose=False, **kw):
     arguments = kw.get('arguments', [])[:]
+    if verbose:
+      arguments.insert(0, '-v')
 
     # Add a -C output/path to the command line.
     arguments.append('-C')
@@ -1422,7 +1426,7 @@ def TestGyp(**kw):
     platform_mismatch = ''
     if platform in excluded_platforms:
       platform_mismatch = 'Test excluded for platform %s' % platform
-    if platform not in explicit_platforms:
+    if explicit_platforms and platform not in explicit_platforms:
       platform_mismatch = 'Test not explicitly included for platforms %s' % platform
     if platform_mismatch:
       print(platform_mismatch)


### PR DESCRIPTION
Regression - Changes default Windows platform for MSBuild projects
Regression - Wrong way to deduce default host `CC` for `make`
Bug - Handle `.s/.S` files for MSBuild
Bug - test `platforms` exclusion rule parsing