### PR TITLE
issue-39 - Added a default `knownRegions` key to `xcodeproj_file.py` …

### DIFF
--- a/gyp/generator/xcodeproj_file.py
+++ b/gyp/generator/xcodeproj_file.py
@@ -2576,6 +2576,7 @@ class PBXProject(XCContainerPortal):
     'buildConfigurationList': [0, XCConfigurationList, 1, 1, XCConfigurationList()],
     'compatibilityVersion':   [0, str,                 0, 1, 'Xcode 3.2'],
     'hasScannedForEncodings': [0, int,                 0, 1, 1],
+    'knownRegions':           [0, list,                0, 1, ['en', 'Base']],
     'mainGroup':              [0, PBXGroup,            1, 1, PBXGroup()],
     'projectDirPath':         [0, str,                 0, 1, ''],
     'projectReferences':      [1, dict,                0, 0],


### PR DESCRIPTION
…in the section that updates the schema for the default values on the root `PBXProject` section

 * This is to silence a new warning that Xcode 10.2 throws for any project created with gyp
 * Previously, this was auto-created in certain circumstances by Xcode with no warning, which is why this change is needed
 * The warning is only shown one per Xcode launch, so a full reboot of the app must be made to test this change