### PR TITLE
src,macos: fix mutually exclusive flags

### DIFF
--- a/gyp/xcode_emulation.py
+++ b/gyp/xcode_emulation.py
@@ -525,7 +525,6 @@ class XcodeSettings(object):
     return XcodeSettings._sdk_path_cache[sdk_root]
 
   def _AppendPlatformVersionMinFlags(self, lst):
-    self._Appendf(lst, 'MACOSX_DEPLOYMENT_TARGET', '-mmacosx-version-min=%s')
     if 'IPHONEOS_DEPLOYMENT_TARGET' in self._Settings():
       # TODO: Implement this better?
       sdk_path_basename = os.path.basename(self._SdkPath())
@@ -535,6 +534,8 @@ class XcodeSettings(object):
       else:
         self._Appendf(lst, 'IPHONEOS_DEPLOYMENT_TARGET',
                       '-miphoneos-version-min=%s')
+    else:
+      self._Appendf(lst, 'MACOSX_DEPLOYMENT_TARGET', '-mmacosx-version-min=%s')
 
   def GetCflags(self, configname, arch=None):
     """Returns flags that need to be added to .c, .cc, .m, and .mm


### PR DESCRIPTION
If IPHONEOS_DEPLOYMENT_TARGET is specified, don't append MACOSX_DEPLOYMENT_TARGET flags.

When building for iOS, it's an error to have both `-mmacosx-version-min=...` and `-miphoneos-version-min=...` compiler flags.

This PR ensures that if IPHONEOS_DEPLOYMENT_TARGET is specified, no `-mmacosx-version-min=...` flags will be emitted.

See also nodejs/node-gyp#1737