### PR TITLE
Fix tests on macOS for -f make,ninja

### DIFF
--- a/test/mac/archs/test-archs-multiarch.gyp
+++ b/test/mac/archs/test-archs-multiarch.gyp
@@ -9,7 +9,7 @@
       'type': 'static_library',
       'sources': [ 'my_file.cc' ],
       'xcode_settings': {
-        'ARCHS': [ 'i386', 'x86_64' ],
+        'ARCHS': [ 'x86_64' ],
       },
     },
     {
@@ -17,7 +17,7 @@
       'type': 'shared_library',
       'sources': [ 'my_file.cc' ],
       'xcode_settings': {
-        'ARCHS': [ 'i386', 'x86_64' ],
+        'ARCHS': [ 'x86_64' ],
       },
     },
     {
@@ -27,7 +27,7 @@
       'mac_bundle': 1,
       'sources': [ 'my_file.cc' ],
       'xcode_settings': {
-        'ARCHS': [ 'i386', 'x86_64' ],
+        'ARCHS': [ 'x86_64' ],
       },
     },
     {
@@ -35,7 +35,7 @@
       'type': 'loadable_module',
       'sources': [ 'my_file.cc' ],
       'xcode_settings': {
-        'ARCHS': [ 'i386', 'x86_64' ],
+        'ARCHS': [ 'x86_64' ],
       },
     },
     {
@@ -45,7 +45,7 @@
       'mac_bundle': 1,
       'sources': [ 'my_file.cc' ],
       'xcode_settings': {
-        'ARCHS': [ 'i386', 'x86_64' ],
+        'ARCHS': [ 'x86_64' ],
       },
     },
     {
@@ -53,7 +53,7 @@
       'type': 'executable',
       'sources': [ 'empty_main.cc' ],
       'xcode_settings': {
-        'ARCHS': [ 'i386', 'x86_64' ],
+        'ARCHS': [ 'x86_64' ],
       },
     },
     {
@@ -63,7 +63,7 @@
       'mac_bundle': 1,
       'sources': [ 'empty_main.cc' ],
       'xcode_settings': {
-        'ARCHS': [ 'i386', 'x86_64' ],
+        'ARCHS': [ 'x86_64' ],
       },
     },
     # This only needs to compile.
@@ -85,7 +85,7 @@
       ],
       'sources': [],
       'xcode_settings': {
-        'ARCHS': ['i386', 'x86_64'],
+        'ARCHS': ['x86_64'],
       },
     },
   ]

--- a/test/mac/archs/test-dependencies.gyp
+++ b/test/mac/archs/test-dependencies.gyp
@@ -5,7 +5,7 @@
 {
   'target_defaults': {
     'xcode_settings': {
-      'ARCHS': ['i386', 'x86_64'],
+      'ARCHS': ['x86_64'],
     },
   },
   'targets': [

--- a/test/mac/archs/test-valid-archs.gyp
+++ b/test/mac/archs/test-valid-archs.gyp
@@ -10,7 +10,7 @@
     'type': 'static_library',
     'sources': [ 'my_file.cc' ],
     'xcode_settings': {
-      'ARCHS': ['i386', 'x86_64', 'unknown-arch'],
+      'ARCHS': ['x86_64', 'unknown-arch'],
       'VALID_ARCHS': ['x86_64'],
     },
   },
@@ -21,7 +21,7 @@
     'dependencies': [ 'lib' ],
     'sources': [ 'my_main_file.cc' ],
     'xcode_settings': {
-      'ARCHS': ['i386', 'x86_64', 'unknown-arch'],
+      'ARCHS': ['x86_64', 'unknown-arch'],
       'VALID_ARCHS': ['x86_64'],
     },
   }]

--- a/test/mac/deployment-target/deployment-target.gyp
+++ b/test/mac/deployment-target/deployment-target.gyp
@@ -2,25 +2,30 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 {
+  'xcode_settings': {
+    'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
+    'CLANG_CXX_LANGUAGE_STANDARD': 'c++14',
+    'CLANG_CXX_LIBRARY': 'libc++',
+  },
   'targets': [
     {
-      'target_name': 'macosx-version-min-10.5',
+      'target_name': 'macosx-version-min-10.9',
       'type': 'executable',
       'sources': [ 'check-version-min.c', ],
-      'defines': [ 'GYPTEST_MAC_VERSION_MIN=1050', ],
+      'defines': [ 'GYPTEST_MAC_VERSION_MIN=__MAC_10_9', ],
       'xcode_settings': {
         'SDKROOT': 'macosx',
-        'MACOSX_DEPLOYMENT_TARGET': '10.5',
+        'MACOSX_DEPLOYMENT_TARGET': '10.9',
       },
     },
     {
-      'target_name': 'macosx-version-min-10.6',
+      'target_name': 'macosx-version-min-10.14',
       'type': 'executable',
       'sources': [ 'check-version-min.c', ],
-      'defines': [ 'GYPTEST_MAC_VERSION_MIN=1060', ],
+      'defines': [ 'GYPTEST_MAC_VERSION_MIN=__MAC_10_14', ],
       'xcode_settings': {
         'SDKROOT': 'macosx',
-        'MACOSX_DEPLOYMENT_TARGET': '10.6',
+        'MACOSX_DEPLOYMENT_TARGET': '10.14',
       },
     },
   ],

--- a/test/mac/gyptest-archs.py
+++ b/test/mac/gyptest-archs.py
@@ -64,18 +64,18 @@ for target in targets:
 
 result_file = test.built_file_path('static_32_64', chdir='archs', type=test.STATIC_LIB)
 test.must_exist(result_file)
-TestGyp.CheckFileType_macOS(test, result_file, ['i386', 'x86_64'])
+TestGyp.CheckFileType_macOS(test, result_file, ['x86_64'])
 
 result_file = test.built_file_path('shared_32_64', chdir='archs', type=test.SHARED_LIB)
 test.must_exist(result_file)
-TestGyp.CheckFileType_macOS(test, result_file, ['i386', 'x86_64'])
+TestGyp.CheckFileType_macOS(test, result_file, ['x86_64'])
 
 result_file = test.built_file_path('My Framework.framework/My Framework',
                                    chdir='archs')
 test.must_exist(result_file)
-TestGyp.CheckFileType_macOS(test, result_file, ['i386', 'x86_64'])
+TestGyp.CheckFileType_macOS(test, result_file, ['x86_64'])
 # Check that symbol "_x" made it into both versions of the binary:
-for arch in ['i386', 'x86_64']:
+for arch in ['x86_64']:
   out = subprocess.check_output(['nm', '-arch', arch, result_file]).decode('utf-8')
   if not 'D _x' in out:
     # This can only flakily fail, due to process ordering issues. If this
@@ -85,9 +85,9 @@ for arch in ['i386', 'x86_64']:
 result_file = test.built_file_path(
   'exe_32_64', chdir='archs', type=test.EXECUTABLE)
 test.must_exist(result_file)
-TestGyp.CheckFileType_macOS(test, result_file, ['i386', 'x86_64'])
+TestGyp.CheckFileType_macOS(test, result_file, ['x86_64'])
 
 result_file = test.built_file_path('Test App.app/Contents/MacOS/Test App',
                                    chdir='archs')
 test.must_exist(result_file)
-TestGyp.CheckFileType_macOS(test, result_file, ['i386', 'x86_64'])
+TestGyp.CheckFileType_macOS(test, result_file, ['x86_64'])

--- a/test/mac/gyptest-deployment-target.py
+++ b/test/mac/gyptest-deployment-target.py
@@ -15,10 +15,6 @@ import sys
 if sys.platform == 'darwin':
   test = TestGyp.TestGyp(formats=['make', 'ninja', 'xcode'])
 
-  if test.format == 'make':
-    # This is failing because of a deprecation warning for libstdc++.
-    test.skip_test()  # bug=533
-
   test.run_gyp('deployment-target.gyp', chdir='deployment-target')
 
   test.build('deployment-target.gyp', test.ALL, chdir='deployment-target')

--- a/test/mac/type_envvars/test_check_sdkroot.sh
+++ b/test/mac/type_envvars/test_check_sdkroot.sh
@@ -5,43 +5,5 @@
 
 set -e
 
-# `xcodebuild -version` output looks like
-#    Xcode 4.6.3
-#    Build version 4H1503
-# or like
-#    Xcode 4.2
-#    Build version 4C199
-# or like
-#    Xcode 3.2.6
-#    Component versions: DevToolsCore-1809.0; DevToolsSupport-1806.0
-#    BuildVersion: 10M2518
-# Convert that to '0463', '0420' and '0326' respectively.
-function xcodeversion() {
-  xcodebuild -version | awk '/Xcode ([0-9]+\.[0-9]+(\.[0-9]+)?)/ {
-    version = $2
-    gsub(/\./, "", version)
-    if (length(version) < 3) {
-      version = version "0"
-    }
-    if (length(version) < 4) {
-      version = "0" version
-    }
-  }
-  END { print version }'
-}
-
-# Returns true if |string1| is smaller than |string2|.
-# This function assumes that both strings represent Xcode version numbers
-# as returned by |xcodeversion|.
-function smaller() {
-  local min="$(echo -ne "${1}\n${2}\n" | sort -n | head -n1)"
-  test "${min}" != "${2}"
-}
-
-if [[ "$(xcodeversion)" < "0500" ]]; then
-  # Xcode version is older than 5.0, check that SDKROOT is set but empty.
-  [[ -z "${SDKROOT}" && -z "${SDKROOT-_}" ]]
-else
-  # Xcode version is newer than 5.0, check that SDKROOT is set.
-  [[ "${SDKROOT}" == "$(xcodebuild -version -sdk '' Path)" ]]
-fi
+# Xcode version is newer than 5.0, check that SDKROOT is set.
+[[ "${SDKROOT}" == "$(xcodebuild -version -sdk '' Path)" ]]

--- a/testlib/TestGyp.py
+++ b/testlib/TestGyp.py
@@ -1360,13 +1360,14 @@ def CheckFileType_macOS(test, file, archs):
   proc = subprocess.Popen(['lipo', '-info', file], stdout=subprocess.PIPE)
   o = proc.communicate()[0].decode('utf-8').strip()
   assert not proc.returncode
-  if len(archs) == 1:
-    pattern = re.compile('^Non-fat file: (.*) is architecture: (.*)$')
-  else:
-    pattern = re.compile('^Architectures in the fat file: (.*) are: (.*)$')
+  pattern = re.compile('^Non-fat file: (.*) is architecture: (.*)$')
   match = pattern.match(o)
   if match is None:
+    pattern = re.compile('^Architectures in the fat file: (.*) are: (.*)$')
+    match = pattern.match(o)
+  if match is None:
     print('Output does not match expected pattern: %s' % pattern.pattern)
+    print('Output: %s' % o)
     test.fail_test()
   else:
     found_file, found_archs = match.groups()


### PR DESCRIPTION
I noticed `pipenv run -v test -f make,ninja` was failing on macOS:

```
$ pipenv run -v test -f make,ninja

... snip ...

Failed the following 4 tests:
	(test/mac/gyptest-archs.py) make
	(test/mac/gyptest-deployment-target.py) ninja
	(test/mac/gyptest-type-envvars.py) make
	(test/mac/gyptest-type-envvars.py) ninja

Ran 714 tests in 513.727s, 4 failed.
```

This is my attempt at fixing them.