### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/gyp/input.py
+++ b/gyp/input.py
@@ -958,7 +958,7 @@ def LoadVariablesFromVariablesDict(variables, the_dict, the_dict_key):
       if variable_name in variables:
         # If the variable is already set, don't set it.
         continue
-      if the_dict_key is 'variables' and variable_name in the_dict:
+      if the_dict_key == 'variables' and variable_name in the_dict:
         # If the variable is set without a % in the_dict, and the_dict is a
         # variables dict (making |variables| a varaibles sub-dict of a
         # variables dict), use the_dict's definition.

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,4 @@ entry_points = {'console_scripts': ['gyp=gyp:script_main']}
 
 [flake8]
 exclude = .venv,out,testlib/SConsLib
-select = E9,F8
+select = E9,F63,F7,F8

--- a/test/linux/ldflags-duplicates/check-ldflags.py
+++ b/test/linux/ldflags-duplicates/check-ldflags.py
@@ -13,16 +13,16 @@ from __future__ import print_function
 import sys
 
 def CheckContainsFlags(args, substring):
-  if args.find(substring) is -1:
+  found = substring in args
+  if not found:
     print('ERROR: Linker arguments "%s" are missing in "%s"' % (substring,
                                                                 args))
-    return False;
-  return True;
+  return found
 
 if __name__ == '__main__':
   args = " ".join(sys.argv)
-  print("args = " +args)
-  if not CheckContainsFlags(args, 'lib1.a -Wl,--no-whole-archive') \
-    or not CheckContainsFlags(args, 'lib2.a -Wl,--no-whole-archive'):
-    sys.exit(1);
+  print("args = " + args)
+  if (not CheckContainsFlags(args, 'lib1.a -Wl,--no-whole-archive')
+      or not CheckContainsFlags(args, 'lib2.a -Wl,--no-whole-archive')):
+    sys.exit(1)
   sys.exit(0)


### PR DESCRIPTION
Identity is not the same thing as equality in Python.

$ __python__
```
>>> the_dict_key = 'varia'
>>> the_dict_key += 'bles'
>>> the_dict_key == 'variables'
True
>>> the_dict_key is 'variables'
False
```

Also add a few more __flake8__ tests:
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).
* F7 tests logic errors and syntax errors in type hints