### PR TITLE
build: test on the current osx_image: xcode11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ windows-setup-steps: &windows-setup-steps
 
 osx-setup-steps: &osx-setup-steps
   os: osx
+  osx_image: xcode11
   language: cpp  # 'language: python' is not yet supported on macOS
   # before_install: brew upgrade python  # takes too long
   install:


### PR DESCRIPTION
Four Travis CI tests fail when the current __osx_image: xcode11__ is used.

https://travis-ci.com/refack/GYP/jobs/219315333#L3622-L3628
```
Failed the following 4 tests:
	(test/mac/gyptest-archs.py) make
	(test/mac/gyptest-archs.py) ninja
	(test/mac/gyptest-clang-cxx-library.py) ninja
	(test/mac/gyptest-postbuild-copy-bundle.py) ninja
Ran 714 tests in 1050.327s, 4 failed.
```
https://docs.travis-ci.com/user/reference/osx/#xcode-version