### PR TITLE
input.py: for key, value in zip(node.keys, node.values):

### DIFF
--- a/gyp/input.py
+++ b/gyp/input.py
@@ -192,7 +192,7 @@ def CheckedEval(file_contents):
 def CheckNode(node, keypath):
   if isinstance(node, ast.Dict):
     dict = {}
-    for key, value in zip(node.keys, node.values):
+    for key, value in node.items():
       assert isinstance(key, ast.Str)
       key = key.s
       if key in dict:


### PR DESCRIPTION
This was changed at https://github.com/refack/GYP3/commit/f989ef9f1c41f04267eb18bed24b880ad0f8b9ec

Original: __for key, value in zip(node.keys, node.values):__

Don't we really want: __for key, value in zip(node.keys(), node.values()):__

Isn't that more concisely / Pythonicly rewritten as: __for key, value in node.items():__